### PR TITLE
Adding disable_gpg_check flag to install-docker role

### DIFF
--- a/roles/install-docker/tasks/main.yaml
+++ b/roles/install-docker/tasks/main.yaml
@@ -5,6 +5,7 @@
       - https://oplab9.parqtec.unicamp.br/pub/ppc64el/docker/version-19.03.8/centos/docker-ce-cli-19.03.8-3.el7.ppc64le.rpm
       - https://dl.fedoraproject.org/pub/epel/7/ppc64le/Packages/c/containerd-1.2.4-1.el7.ppc64le.rpm
     state: present
+    disable_gpg_check: True
 
 - name: Create a /etc/docker dir
   file:


### PR DESCRIPTION
As result of this change:  [#71537](https://github.com/ansible/ansible/pull/71537) ansible started ensuring packages are gpg-verified.
Thus the ansible playbook install-k8s.yml is failing with the error "Failed to validate GPG signature for docker-ce-3:19.03.8-3.el7.ppc64le" 
ansible version 2.9.13