### PR TITLE
Add mirror docker registry

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -11,6 +11,9 @@ kubeconfig_path: kubeconfig
 
 cgroup_driver: systemd
 MTU: 9000
+# additional docker mirrors to avoid the flood to the hub.docker.com
+registry_mirrors:
+  - https://mirror.gcr.io
 
 # used for kubeadm init
 apiserver_port: 992

--- a/roles/install-docker/templates/daemon.j2
+++ b/roles/install-docker/templates/daemon.j2
@@ -9,4 +9,7 @@
   "overlay2.override_kernel_check=true"
 ],
 "mtu": {{ MTU }}
+{% if (registry_mirrors is defined) and registry_mirrors -%},
+"registry-mirrors": [ {{ registry_mirrors|map("to_json")|join(", ") }} ]
+{% endif %}
 }


### PR DESCRIPTION
More information:

https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/
https://cloud.google.com/container-registry/docs/pulling-cached-images#configure