### PR TITLE
Change the calico manifest download task to fix the CI error on PowerVS

### DIFF
--- a/roles/install-calico/tasks/main.yml
+++ b/roles/install-calico/tasks/main.yml
@@ -1,8 +1,9 @@
 - name: Download calico manifest
-  get_url:
-    url: https://docs.projectcalico.org/manifests/calico.yaml
-    dest: /tmp/calico.yaml
-    mode: '0755'
+  shell: |
+    wget --limit-rate 1k https://docs.projectcalico.org/manifests/calico.yaml -O /tmp/calico.yaml
+    chmod 0755 /tmp/calico.yaml
+  args:
+    warn: false
 
 - name: Set veth_mtu
   replace:


### PR DESCRIPTION
This change is to avoid the below error on PowerVS while the conformance jobs use the ansible playbook to create k8s cluster.

```
TASK [install-calico : Download calico manifest] *******************************
fatal: [163.68.65.236]: FAILED! => {"changed": false, "dest": "/tmp/calico.yaml", "elapsed": 10, "msg": "Request failed: <urlopen error _ssl.c:880: The handshake operation timed out>", "url": "https://docs.projectcalico.org/manifests/calico.yaml"}
```
https://github.ibm.com/powercloud/container-dev/issues/1467 has more details.
As `get_url` module of ansible doesn't have the option to limit the download rate, switching to shell and then `wget`.

https://prow.ppc64le-cloud.org/view/gs/ppc64le-kubernetes/logs/periodic-kubernetes-conformance-test-ppc64le/1390216828562706432 is the failed job.