### PR TITLE
Add wget as pre-requisite in install-calico playbook

### DIFF
--- a/roles/install-calico/tasks/main.yml
+++ b/roles/install-calico/tasks/main.yml
@@ -1,3 +1,8 @@
+- name: Install prereq wget
+  yum:
+    name: wget
+    state: present
+
 - name: Download calico manifest
   shell: |
     wget --limit-rate 1k https://docs.projectcalico.org/manifests/calico.yaml -O /tmp/calico.yaml


### PR DESCRIPTION
CI Conformance jobs are throwing below error:
```
fatal: [163.68.64.165]: FAILED! => {"changed": true, "cmd": "wget --limit-rate 1k https://docs.projectcalico.org/manifests/calico.yaml -O /tmp/calico.yaml\nchmod 0755 /tmp/calico.yaml\n", "delta": "0:00:01.004447", "end": "2021-05-10 12:09:04.078728", "msg": "non-zero return code", "rc": 1, "start": "2021-05-10 12:09:03.074281", "stderr": "/bin/sh: wget: command not found\nchmod: cannot access '/tmp/calico.yaml': No such file or directory", "stderr_lines": ["/bin/sh: wget: command not found", "chmod: cannot access '/tmp/calico.yaml': No such file or directory"], "stdout": "", "stdout_lines": []}
```
Adding `wget` as pre-requisite to install-calico playbook.
