### PR TITLE
Enable multiple extra_cert

### DIFF
--- a/roles/install-k8s/templates/kubeadm.yaml.j2
+++ b/roles/install-k8s/templates/kubeadm.yaml.j2
@@ -28,7 +28,10 @@ apiServer:
   timeoutForControlPlane: 4m0s
 {% if (extra_cert is defined) and extra_cert %}
   certSANs:
-    - {{ extra_cert }}
+{% set list1 = extra_cert.split(',') %}
+{% for item in list1 %}
+    - {{ item }}
+{% endfor %}
 {% endif %}
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1


### PR DESCRIPTION
This will enable multiple entries in the extra_cert variable.

usage:

```json
"extra_cert": "k8s-cluster.ppc64le-cloud.org,651b7744-eu-gb.lb.appdomain.cloud,k8s-cluster-int.ppc64le-cloud.org"
```