### PR TITLE
Parameterize kubelet.service.j2 config file for kube-perf-tests

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -31,6 +31,7 @@ extra_cert: "{{ cluster_name }}-master.{{ powervs_dns_zone }}"
 # https://github.com/kubernetes/kubernetes/blob/66334f02e8c520df7973c397246da82cd4db2769/cmd/kubeadm/app/util/version_test.go#L193:L199 for more information
 release_marker: ci/latest
 bootstrap_token: abcdef.0123456789abcdef
+kubelet_service_file: "kubelet.service.j2"
 
 # in the format of: https://storage.googleapis.com/{{ bucket }}/{{ directory }}/{{ build_version }}/kubernetes-client-linux-ppc64le.tar.gz
 # used for downloading the kubernetes bits

--- a/roles/install-k8s/tasks/main.yml
+++ b/roles/install-k8s/tasks/main.yml
@@ -21,9 +21,11 @@
 
 - name: Template a kubelet service to /usr/lib/systemd/system/kubelet.service
   template:
-    src: kubelet.service.j2
+    src: "{{ kubelet_service_file }}"
     dest: /usr/lib/systemd/system/kubelet.service
     mode: '0644'
+  vars:
+    kubelet_service_file: "{{ kubelet_service }}"
 
 - name: Enable and start kubelet
   systemd:

--- a/roles/install-k8s/templates/kubelet.service-perf.j2
+++ b/roles/install-k8s/templates/kubelet.service-perf.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=kubelet: The Kubernetes Node Agent
+Documentation=https://kubernetes.io/docs/
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml --kube-api-qps=100 --kube-api-burst=100 --max-pods 130"
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_KUBEADM_ARGS=--cgroup-driver={{ cgroup_driver }} --network-plugin=cni"
+ExecStart=/usr/local/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Non Breaking change to parameterize Kubelet Config file to enable passing different kubelet config file required for kube-perf-tests execution.
Change has been tested and runs fine.
This PR will be followed by another PR for kubetest2-plugins repo once the approach is finalized.