### PR TITLE
Fix for PR #17

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -31,6 +31,7 @@ extra_cert: "{{ cluster_name }}-master.{{ powervs_dns_zone }}"
 # https://github.com/kubernetes/kubernetes/blob/66334f02e8c520df7973c397246da82cd4db2769/cmd/kubeadm/app/util/version_test.go#L193:L199 for more information
 release_marker: ci/latest
 bootstrap_token: abcdef.0123456789abcdef
+kubelet_extra_args: ""
 
 # in the format of: https://storage.googleapis.com/{{ bucket }}/{{ directory }}/{{ build_version }}/kubernetes-client-linux-ppc64le.tar.gz
 # used for downloading the kubernetes bits

--- a/roles/install-k8s/tasks/main.yml
+++ b/roles/install-k8s/tasks/main.yml
@@ -24,8 +24,6 @@
     src: kubelet.service.j2
     dest: /usr/lib/systemd/system/kubelet.service
     mode: '0644'
-  vars:
-    KUBELET_EXTRA_ARGS: "{{ lookup('env','KUBELET_EXTRA_ARGS') | default('', True) }}"
 
 - name: Enable and start kubelet
   systemd:

--- a/roles/install-k8s/templates/kubelet.service.j2
+++ b/roles/install-k8s/templates/kubelet.service.j2
@@ -8,7 +8,7 @@ After=network-online.target
 Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
 Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
 Environment="KUBELET_KUBEADM_ARGS=--cgroup-driver={{ cgroup_driver }} --network-plugin=cni"
-ExecStart=/usr/local/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS {{ KUBELET_EXTRA_ARGS }}
+ExecStart=/usr/local/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS {{ kubelet_extra_args }}
 Restart=always
 StartLimitInterval=0
 RestartSec=10


### PR DESCRIPTION
- Fixes issues with https://github.com/ppc64le-cloud/k8s-ansible/pull/17
- extra args for kubelet config can be passed from kubetest command using --extra-args option as key:value pair
- Tested with an e2e execution through kubetest2 tf command and runs fine.