### PR TITLE
Conditional Master Node Taint Removal

### DIFF
--- a/roles/install-k8s/tasks/main.yml
+++ b/roles/install-k8s/tasks/main.yml
@@ -65,7 +65,7 @@
   command: "kubectl taint nodes --all node-role.kubernetes.io/master-"
   environment:
     KUBECONFIG: /etc/kubernetes/admin.conf
-  when: node_type == "master"
+  when: node_type == "master" and not ('workers' in groups and groups['workers'])
 
 - name: Get the kubeadm join command from the Kubernetes master.
   command: kubeadm token create --print-join-command


### PR DESCRIPTION
This validates 3 conditions and will remove the master node taint only when all of the below conditions are satisfied - 
- workers group does not exist in hosts inventory file
- If workers group is defined but empty
- node_type == "master"

This has been tested and works fine - 

**When both workers and master exist in host file - Taint is not removed** 

```
TASK [install-k8s : remove taint] **************************************************************************************************************************************************************************
skipping: [158.175.162.99]
skipping: [158.175.162.100]
```

**When worker group is defined but is empty (no worker nodes) -Taint is removed** 

Note - Ignore the error as this was tested on a cluster which had no taints and only conditional command execution was validated here

```
TASK [install-k8s : remove taint] **************************************************************************************************************************************************************************
fatal: [158.175.162.99]: FAILED! => {"changed": true, "cmd": ["kubectl", "taint", "nodes", "--all", "node-role.kubernetes.io/master-"], "delta": "0:00:00.159261", "end": "2021-06-30 13:51:08.361151", "msg": "non-zero return code", "rc": 1, "start": "2021-06-30 13:51:08.201890", "stderr": "taint \"node-role.kubernetes.io/master\" not found\ntaint \"node-role.kubernetes.io/master\" not found", "stderr_lines": ["taint \"node-role.kubernetes.io/master\" not found", "taint \"node-role.kubernetes.io/master\" not found"], "stdout": "", "stdout_lines": []}
```

**When only master node is defined - Taint is removed** 

Note - Ignore the error as this was tested on a cluster which had no taints and only conditional command execution was validated here

```
TASK [install-k8s : remove taint] **************************************************************************************************************************************************************************
fatal: [158.175.162.99]: FAILED! => {"changed": true, "cmd": ["kubectl", "taint", "nodes", "--all", "node-role.kubernetes.io/master-"], "delta": "0:00:00.108097", "end": "2021-06-30 13:51:45.372042", "msg": "non-zero return code", "rc": 1, "start": "2021-06-30 13:51:45.263945", "stderr": "taint \"node-role.kubernetes.io/master\" not found\ntaint \"node-role.kubernetes.io/master\" not found", "stderr_lines": ["taint \"node-role.kubernetes.io/master\" not found", "taint \"node-role.kubernetes.io/master\" not found"], "stdout": "", "stdout_lines": []}
```

