### PR TITLE
master node cordon code update for perf run

### DIFF
--- a/install-k8s-perf.yml
+++ b/install-k8s-perf.yml
@@ -1,0 +1,18 @@
+- name: Install Runtime and Kubernetes
+  hosts:
+    - masters
+    - workers
+  roles:
+    - runtime
+    - download-k8s
+    - install-k8s
+
+- name: Install networking - calico
+  hosts: masters
+  roles:
+    - install-calico
+
+- name: Perf Cluster Setup Tasks
+  hosts: masters
+  roles:
+    - perf-cluster-tasks

--- a/roles/perf-cluster-tasks/tasks/main.yml
+++ b/roles/perf-cluster-tasks/tasks/main.yml
@@ -1,0 +1,4 @@
+- name: cordon master node
+  command: "kubectl get node --selector='node-role.kubernetes.io/master' --no-headers | awk '{print $1}' | xargs kubectl cordon"
+  environment:
+    KUBECONFIG: /etc/kubernetes/admin.conf


### PR DESCRIPTION
- Added a new generic perf role - `perf-cluster-tasks` which can be used in the future to add more plays whenever needed for perf runs
- Added 1 play to cordon master node(s)
- Added new install-k8s-perf.yml file as per suggestion with new role inside it.