### PR TITLE
Update to shell from command

### DIFF
--- a/roles/perf-cluster-tasks/tasks/main.yml
+++ b/roles/perf-cluster-tasks/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: cordon master node
-  command: "kubectl get node --selector='node-role.kubernetes.io/master' --no-headers | awk '{print $1}' | xargs kubectl cordon"
+  shell:
+     "kubectl get node --selector='node-role.kubernetes.io/master' --no-headers | awk '{print $1}' | xargs kubectl cordon"
   environment:
     KUBECONFIG: /etc/kubernetes/admin.conf


### PR DESCRIPTION
- update utility to shell from command as command is unable to correctly process special instructions like "|" which is required.