### PR TITLE
Remove the limit on download rate for calico manifest

### DIFF
--- a/roles/install-calico/tasks/main.yml
+++ b/roles/install-calico/tasks/main.yml
@@ -1,14 +1,8 @@
-- name: Install prereq wget
-  yum:
-    name: wget
-    state: present
-
 - name: Download calico manifest
-  shell: |
-    wget --limit-rate 1k https://docs.projectcalico.org/manifests/calico.yaml -O /tmp/calico.yaml
-    chmod 0755 /tmp/calico.yaml
-  args:
-    warn: false
+  get_url:
+    url: https://docs.projectcalico.org/manifests/calico.yaml
+    dest: /tmp/calico.yaml
+    mode: '0755'
 
 - name: Set veth_mtu
   replace:


### PR DESCRIPTION
As per https://github.com/ppc64le-cloud/k8s-ansible/issues/27 I have checked if the download of calico manifest is still needed a limit on the download rate. 
Currently, the download isn't throwing errors in spite of no rate limit.
```
[root@test-calico-dwnload-ratelimit ~]# curl -O https://docs.projectcalico.org/manifests/calico.yaml
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  197k  100  197k    0     0   242k      0 --:--:-- --:--:-- --:--:--  242k
[root@test-calico-dwnload-ratelimit ~]#
```
The above VM was created today in `prow-testbed-osa21`.