### PR TITLE
Use older calico manifest file

### DIFF
--- a/roles/install-calico/tasks/main.yml
+++ b/roles/install-calico/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Download calico manifest
   get_url:
-    url: https://docs.projectcalico.org/manifests/calico.yaml
+    url: https://docs.projectcalico.org/archive/v3.20/manifests/calico.yaml
     dest: /tmp/calico.yaml
     mode: '0755'
 


### PR DESCRIPTION
This patch is to use older calico manifest file `v3.20.2` while installing the calico network addon to k8s cluster.
The latest released calico version `v3.21` is failing a conformance test in k8s cluster.
https://github.com/projectcalico/calico/issues/5089