### PR TITLE
Correct the Syntax Error with group_vars/all

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -17,7 +17,7 @@ kubeconfig_path: kubeconfig
 # valid runtimes: containerd
 runtime: containerd
 # Docker runtime is deprecated after k8s v1.20 - https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/
-This repo also supports installation with docker runtime as per the compatibility with k8s.
+# This repo also supports installation with docker runtime as per the compatibility with k8s.
 
 cgroup_driver: systemd
 # By default it will set to the default interface MTU value, set the MTU here to override it


### PR DESCRIPTION
Missed adding the # symbol for the line to be commented.
This is causing syntax error :(

https://storage.googleapis.com/ppc64le-kubernetes/logs/periodic-kubernetes-containerd-conformance-test-ppc64le/1473667294881124352/build-log.txt
