### PR TITLE
Modify kubeadm and kubelet config files used by install-k8s playbook

### DIFF
--- a/roles/install-k8s/templates/kubeadm.yaml.j2
+++ b/roles/install-k8s/templates/kubeadm.yaml.j2
@@ -1,4 +1,4 @@
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: InitConfiguration
 bootstrapTokens:
 - groups:
@@ -12,12 +12,12 @@ localAPIEndpoint:
   bindPort: {{ apiserver_port }}
 nodeRegistration:
 {% if (runtime is defined) and 'containerd' == runtime %}
-  criSocket: /run/containerd/containerd.sock
+  criSocket: "unix:///run/containerd/containerd.sock"
 {% endif %}
   kubeletExtraArgs:
     cgroup-driver: {{ cgroup_driver }}
 ---
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
 networking:
   serviceSubnet: "10.96.0.0/12"
@@ -38,7 +38,7 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 cgroupDriver: {{ cgroup_driver }}
 ---
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 caCertPath: /etc/kubernetes/pki/ca.crt
 discovery:
   bootstrapToken:
@@ -49,5 +49,5 @@ discovery:
 kind: JoinConfiguration
 nodeRegistration:
 {% if (runtime is defined) and 'containerd' == runtime %}
-  criSocket: /run/containerd/containerd.sock
+  criSocket: "unix:///run/containerd/containerd.sock"
 {% endif %}

--- a/roles/install-k8s/templates/kubelet.service.j2
+++ b/roles/install-k8s/templates/kubelet.service.j2
@@ -7,8 +7,7 @@ After=network-online.target
 [Service]
 Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
 Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
-Environment="KUBELET_KUBEADM_ARGS=--cgroup-driver={{ cgroup_driver }} --network-plugin=cni"
-ExecStart=/usr/local/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS {{ kubelet_extra_args }}
+ExecStart=/usr/local/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_EXTRA_ARGS {{ kubelet_extra_args }}
 Restart=always
 StartLimitInterval=0
 RestartSec=10


### PR DESCRIPTION
For task https://github.ibm.com/powercloud/container-dev/issues/1561
Related PRs:
https://github.com/kubernetes/kubernetes/pull/107013
https://github.com/kubernetes/kubernetes/pull/107295
Related Error:
```
Jan 21 07:57:57 kubeadm-fail kubelet[25421]: Flag --cgroup-driver has been deprecated, This parameter should be set via the config file specified by the Kub>
Jan 21 07:57:57 kubeadm-fail kubelet[25421]: Flag --network-plugin has been deprecated, will be removed along with dockershim.
```
Have verified these changes by creating a k8s cluster on PowerVS through this repo.

This is effecting the below jobs:
periodic-kubernetes-storage-perf-test-ppc64le
periodic-kubernetes-containerd-conformance-test-ppc64le
postsubmit-master-golang-kubernetes-conformance-test-ppc64le

ci-search tool link: https://search.ppc64le-cloud.org/?search=deprecated+API+spec&maxAge=48h&context=3&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job