### PR TITLE
Enable containerd service so as to start by default after reboot

### DIFF
--- a/roles/runtime/tasks/containerd.yaml
+++ b/roles/runtime/tasks/containerd.yaml
@@ -51,7 +51,8 @@
     src: containerd/dropin.conf
     dest: /etc/systemd/system/kubelet.service.d/00-containerd-dropin.conf
 
-- name: Restart containerd
+- name: Enable and Restart containerd
   systemd:
     name: containerd
     state: restarted
+    enabled: yes


### PR DESCRIPTION
Have verified this by provisioning a VM on PowerVS, deploying k8s using this change, and checking if containerd is coming up on its own when the VM is rebooted.