### PR TITLE
Change the calico manifest to latest version

### DIFF
--- a/roles/install-calico/tasks/main.yml
+++ b/roles/install-calico/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Download calico manifest
   get_url:
-    url: https://docs.projectcalico.org/archive/v3.20/manifests/calico.yaml
+    url: https://docs.projectcalico.org/manifests/calico.yaml
     dest: /tmp/calico.yaml
     mode: '0755'
 


### PR DESCRIPTION
This is to fix the failures with https://prow.ppc64le-cloud.org/job-history/gs/ppc64le-kubernetes/logs/periodic-kubernetes-containerd-conformance-test-ppc64le

The current playbook uses the `3.20.5` version of calico manifest.

The calico and coredns pods are coming up successfully when the latest stable calico manifest is used from https://docs.projectcalico.org/manifests/calico.yaml

This could be related to the change
(This change happened around the same timestamp as when the tests started failing) https://github.com/projectcalico/calico/commit/0337a6efbfe8e220be55dc3c8483a1790add0724.

```
[root@config1-1650392795-master tmp]# kubectl get pods -n kube-system | grep calico
calico-kube-controllers-7cb7cc646b-7dbt6            0/1     Pending                 0                8h
calico-node-45nqs                                   0/1     Init:CrashLoopBackOff   108 (57s ago)    8h
calico-node-c6whn                                   0/1     Init:CrashLoopBackOff   108 (23s ago)    8h
calico-node-j4hcr                                   0/1     Init:CrashLoopBackOff   107 (5m9s ago)   8h
[root@config1-1650392795-master tmp]# kubectl describe pod calico-node-c6whn -n kube-system | grep v3.2
    Image:         docker.io/calico/cni:v3.20.5
    Image:         docker.io/calico/cni:v3.20.5
    Image:          docker.io/calico/pod2daemon-flexvol:v3.20.5
    Image:          docker.io/calico/node:v3.20.5
[root@config1-1650392795-master tmp]# 
```

**After deploying the latest stable calico manifest,**

```
[root@config1-1650392795-master tmp]# kubectl get pods -n kube-system | grep calico
calico-kube-controllers-77484fbbb5-qwbzt            1/1     Running   0          90s
calico-node-25x22                                   1/1     Running   0          90s
calico-node-jzvk2                                   1/1     Running   0          90s
calico-node-qklm8                                   1/1     Running   0          90s
[root@config1-1650392795-master tmp]# kubectl describe pod calico-node-c6whn -n kube-system | grep v3.2
Error from server (NotFound): pods "calico-node-c6whn" not found
[root@config1-1650392795-master tmp]# kubectl describe pod calico-node-25x22 -n kube-system | grep v3.2
    Image:         docker.io/calico/cni:v3.22.2
    Image:         docker.io/calico/cni:v3.22.2
    Image:          docker.io/calico/pod2daemon-flexvol:v3.22.2
    Image:          docker.io/calico/node:v3.22.2
  Normal   Pulling    104s               kubelet            Pulling image "docker.io/calico/cni:v3.22.2"
  Normal   Pulled     84s                kubelet            Successfully pulled image "docker.io/calico/cni:v3.22.2" in 19.767549991s
  Normal   Pulled     83s                kubelet            Container image "docker.io/calico/cni:v3.22.2" already present on machine
  Normal   Pulling    82s                kubelet            Pulling image "docker.io/calico/pod2daemon-flexvol:v3.22.2"
  Normal   Pulled     67s                kubelet            Successfully pulled image "docker.io/calico/pod2daemon-flexvol:v3.22.2" in 14.916231233s
  Normal   Pulling    66s                kubelet            Pulling image "docker.io/calico/node:v3.22.2"
  Normal   Pulled     49s                kubelet            Successfully pulled image "docker.io/calico/node:v3.22.2" in 16.606887957s
[root@config1-1650392795-master tmp]#
```