### PR TITLE
Fix the prereq for the container runtime

### DIFF
--- a/roles/runtime/tasks/containerd.yaml
+++ b/roles/runtime/tasks/containerd.yaml
@@ -8,26 +8,6 @@
     state: present
     disable_gpg_check: true
 
-- name: Load kernel modules
-  modprobe:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - overlay
-    - br_netfilter
-
-- name: Sysctl settings
-  sysctl:
-      name: "{{ item }}"
-      sysctl_file: /etc/sysctl.d/99-kubernetes-cri.conf
-      value: 1
-      state: present
-      reload: yes
-  with_items:
-    - net.bridge.bridge-nf-call-iptables
-    - net.ipv4.ip_forward
-    - net.bridge.bridge-nf-call-ip6tables
-
 - name: Create a /etc/containerd dir
   file:
     path: /etc/containerd

--- a/roles/runtime/tasks/main.yaml
+++ b/roles/runtime/tasks/main.yaml
@@ -10,6 +10,35 @@
       shell: subscription-manager register --username {{ username }} --password {{ password }} --auto-attach
       when:  ansible_distribution == "RedHat"
 
+- name: Forwarding IPv4 and letting iptables see bridged traffic
+  block:
+    - name: Loading Modules Boot Time
+      copy:
+        dest: "/etc/modules-load.d/k8s.conf"
+        content: |
+          overlay
+          br_netfilter
+
+    - name: Load kernel modules First time
+      modprobe:
+        name: "{{ item }}"
+        state: present
+      with_items:
+        - overlay
+        - br_netfilter
+
+    - name: Sysctl settings
+      sysctl:
+        name: "{{ item }}"
+        sysctl_file: /etc/sysctl.d/k8s.conf
+        value: 1
+        state: present
+        reload: yes
+      with_items:
+        - net.bridge.bridge-nf-call-iptables
+        - net.bridge.bridge-nf-call-ip6tables
+        - net.ipv4.ip_forward
+
 - name: Common Prerequisites
   block:
     - name: Install crictl


### PR DESCRIPTION
Fixes: #41 

- Moved the prerequisites to the common place for both the runtimes
- Added modules to work properly for boot time