### PR TITLE
Set bind-address for controller-manager and scheduler to 0.0.0.0 and RBAC for /metrics API

### DIFF
--- a/roles/install-calico/tasks/main.yml
+++ b/roles/install-calico/tasks/main.yml
@@ -10,7 +10,7 @@
     regexp: 'veth_mtu\:.*'
     replace: 'veth_mtu: "{{ calico_mtu }}"'
 
-- name: kubectl
+- name: Set up Calico CNI from manifest
   command: kubectl create -f /tmp/calico.yaml
   environment:
     KUBECONFIG: /etc/kubernetes/admin.conf

--- a/roles/install-k8s/templates/kubeadm.yaml.j2
+++ b/roles/install-k8s/templates/kubeadm.yaml.j2
@@ -33,6 +33,14 @@ apiServer:
     - {{ item }}
 {% endfor %}
 {% endif %}
+# The default bind address for the controllerManager and the Scheduler is set to 127.0.0.1
+# To access the /metrics endpoint on kube-scheduler, the bind address is set to 0.0.0.0
+controllerManager:
+  extraArgs:
+    bind-address: "0.0.0.0"
+scheduler:
+  extraArgs:
+    bind-address: "0.0.0.0"
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration

--- a/roles/perf-cluster-tasks/tasks/main.yml
+++ b/roles/perf-cluster-tasks/tasks/main.yml
@@ -1,5 +1,19 @@
-- name: cordon master node
+- name: Cordon master node
   shell:
      "kubectl get node --selector='node-role.kubernetes.io/control-plane' --no-headers | awk '{print $1}' | xargs kubectl cordon"
   environment:
     KUBECONFIG: /etc/kubernetes/admin.conf
+
+# The /metrics API access needs to be enabled to scrape the scheduler metrics.
+# The role associated by the scraper is system:anonymous, hence a Cluster role and a binding is added to enable the API access.
+- name: Add RBAC for /metrics API access
+  shell: |
+     kubectl create clusterrole metrics-viewer --verb=get --non-resource-url=/metrics
+     kubectl create clusterrolebinding perf-metrics-user --clusterrole metrics-viewer --user system:anonymous
+
+# Hold-off from executing tests until all nodes in cluster are Ready
+- name: Wait for nodes to transistion to Ready state
+  shell: kubectl wait --for=condition=Ready nodes --all --timeout=600s
+  register: nodes_ready
+
+- debug: var=nodes_ready.stdout_lines

--- a/roles/perf-cluster-tasks/tasks/main.yml
+++ b/roles/perf-cluster-tasks/tasks/main.yml
@@ -14,6 +14,3 @@
 # Hold-off from executing tests until all nodes in cluster are Ready
 - name: Wait for nodes to transistion to Ready state
   shell: kubectl wait --for=condition=Ready nodes --all --timeout=600s
-  register: nodes_ready
-
-- debug: var=nodes_ready.stdout_lines


### PR DESCRIPTION
The --bind-address flag for the kube-controller-manager and kube-scheduler is set to 0.0.0.0 from the default 127.0.0.1 to allow the scraping of scheduler-metrics, which are required for `periodic-kubernetes-storage-perf-test-ppc64le` tests.

Additionally, the RBAC for accessing the /metrics API has been configured to be accessed only through GET. A cluster-role and role-binding is defined as one of the tasks during the cluster creation to enable API access during test-execution. 