### PR TITLE
Update cri-tools version installed during K8s infra setup.

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -14,6 +14,8 @@ password: <password>
 kubeconfig_path: kubeconfig
 
 ##### Runtime Configurations #####
+# cri-tools version
+crictl_verison: v1.25.0
 # valid runtimes: containerd
 runtime: containerd
 # Docker runtime is deprecated after k8s v1.20 - https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/

--- a/group_vars/all
+++ b/group_vars/all
@@ -15,7 +15,7 @@ kubeconfig_path: kubeconfig
 
 ##### Runtime Configurations #####
 # cri-tools version
-crictl_verison: v1.25.0
+critools_version: v1.26.0
 # valid runtimes: containerd
 runtime: containerd
 # Docker runtime is deprecated after k8s v1.20 - https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/

--- a/roles/install-calico/tasks/main.yml
+++ b/roles/install-calico/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Download calico manifest
+- name: Download calico manifest - {{ calico_version }}
   get_url:
     url: "https://raw.githubusercontent.com/projectcalico/calico/{{ calico_version }}/manifests/calico.yaml"
     dest: /tmp/calico.yaml

--- a/roles/runtime/tasks/main.yaml
+++ b/roles/runtime/tasks/main.yaml
@@ -41,9 +41,9 @@
 
 - name: Common Prerequisites
   block:
-    - name: Install crictl
+    - name: Install crictl - {{ crictl_verison }}
       unarchive:
-        src: "https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.24.2/crictl-v1.24.2-linux-ppc64le.tar.gz"
+        src: "https://github.com/kubernetes-sigs/cri-tools/releases/download/{{ crictl_verison }}/crictl-{{ crictl_verison }}-linux-ppc64le.tar.gz"
         dest: "/usr/local/bin/"
         remote_src: yes
 

--- a/roles/runtime/tasks/main.yaml
+++ b/roles/runtime/tasks/main.yaml
@@ -41,9 +41,9 @@
 
 - name: Common Prerequisites
   block:
-    - name: Install crictl - {{ crictl_verison }}
+    - name: Install crictl - {{ critools_version }}
       unarchive:
-        src: "https://github.com/kubernetes-sigs/cri-tools/releases/download/{{ crictl_verison }}/crictl-{{ crictl_verison }}-linux-ppc64le.tar.gz"
+        src: "https://github.com/kubernetes-sigs/cri-tools/releases/download/{{ critools_version }}/crictl-{{ critools_version }}-linux-ppc64le.tar.gz"
         dest: "/usr/local/bin/"
         remote_src: yes
 


### PR DESCRIPTION
Changes: 
1. Bump the cri-tools version from v1.24.2 to [v1.26.0](https://github.com/kubernetes-sigs/cri-tools/releases/tag/v1.26.0)
2. Display calico and cri-tools version installed in task during playbook execution. 