### PR TITLE
Calico - Version update and operator based installation.

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -33,6 +33,7 @@ registry_mirrors:
 apiserver_port: 992
 cluster_name: "k8s-cluster-1"
 powervs_dns_zone: "k8s.test"
+pod_subnet: 172.20.0.0/16
 extra_cert: "{{ cluster_name }}-master.{{ powervs_dns_zone }}"
 # https://github.com/kubernetes/kubernetes/blob/66334f02e8c520df7973c397246da82cd4db2769/cmd/kubeadm/app/util/version_test.go#L193:L199 for more information
 release_marker: ci/latest
@@ -56,4 +57,7 @@ build_version: v1.20.0-alpha.0.1402+d39214ade1d60c
 # build_version: d39214ade1d60c
 
 ##### Calico Configurations #####
-calico_version: v3.24.1
+calico_version: v3.24.5
+# The available methods of installation for Calico can be either using the tigera operator, or using the manifest.
+# Choose between "operator" or "manifest" (default) for the desired installation method.
+calico_installation_type: manifest

--- a/roles/install-calico/tasks/calico-manifest.yaml
+++ b/roles/install-calico/tasks/calico-manifest.yaml
@@ -1,0 +1,16 @@
+- name: Download calico manifest - {{ calico_version }}
+  get_url:
+    url: "https://raw.githubusercontent.com/projectcalico/calico/{{ calico_version }}/manifests/calico.yaml"
+    dest: /tmp/calico.yaml
+    mode: '0755'
+
+- name: Set veth_mtu
+  replace:
+    path: /tmp/calico.yaml
+    regexp: 'veth_mtu\:.*'
+    replace: 'veth_mtu: "{{ calico_mtu }}"'
+
+- name: Set up Calico CNI from manifest
+  command: kubectl create -f /tmp/calico.yaml
+  environment:
+    KUBECONFIG: /etc/kubernetes/admin.conf

--- a/roles/install-calico/tasks/calico-operator.yaml
+++ b/roles/install-calico/tasks/calico-operator.yaml
@@ -1,0 +1,38 @@
+- name: Set up Calico - {{ calico_version }} using tigera operator.
+  command: kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/{{ calico_version }}/manifests/tigera-operator.yaml
+  environment:
+    KUBECONFIG: /etc/kubernetes/admin.conf
+
+- name: Download Calico custom-resource manifest.
+  get_url:
+    url: "https://raw.githubusercontent.com/projectcalico/calico/{{ calico_version }}/manifests/custom-resources.yaml"
+    dest: /tmp/calico.yaml
+    mode: '0755'
+
+# Guide to set v-eth mtu for calico - https://projectcalico.docs.tigera.io/networking/mtu
+# TODO: Identify a safer way to make changes to .yaml file.
+- name: Set veth_mtu to {{ calico_mtu }}
+  lineinfile:
+    path: /tmp/calico.yaml
+    insertafter: "calicoNetwork:"
+    line: "    mtu: {{ calico_mtu }}"
+
+- name: Update CIDR for PodSubnet to {{ pod_subnet }}
+  replace:
+    path: /tmp/calico.yaml
+    regexp: "cidr:.*"
+    replace: "cidr: {{ pod_subnet }}"
+
+- name: Set up Calico CNI from manifest
+  command: kubectl create -f /tmp/calico.yaml
+
+# TODO: Switch to suitable logic when - https://github.com/kubernetes/kubernetes/issues/83242 is fixed.
+- name: Wait until namespace is created for calico-apiserver.
+  command: kubectl get namespace calico-apiserver
+  register: result
+  until: result.stdout.find("Active") != -1
+  retries: 18
+  delay: 5
+
+- name: Wait for tigera operator to set up calico api-server.
+  command: kubectl rollout status deployment calico-apiserver -n calico-apiserver --timeout=60s

--- a/roles/install-calico/tasks/main.yml
+++ b/roles/install-calico/tasks/main.yml
@@ -1,16 +1,8 @@
-- name: Download calico manifest - {{ calico_version }}
-  get_url:
-    url: "https://raw.githubusercontent.com/projectcalico/calico/{{ calico_version }}/manifests/calico.yaml"
-    dest: /tmp/calico.yaml
-    mode: '0755'
+- name: Install Calico using manifest.
+  import_tasks: calico-manifest.yaml
+  when: calico_installation_type == "manifest"
 
-- name: Set veth_mtu
-  replace:
-    path: /tmp/calico.yaml
-    regexp: 'veth_mtu\:.*'
-    replace: 'veth_mtu: "{{ calico_mtu }}"'
+- name: Install Calico using tigera operator.
+  import_tasks: calico-operator.yaml
+  when: calico_installation_type == "operator"
 
-- name: Set up Calico CNI from manifest
-  command: kubectl create -f /tmp/calico.yaml
-  environment:
-    KUBECONFIG: /etc/kubernetes/admin.conf

--- a/roles/install-k8s/templates/kubeadm.yaml.j2
+++ b/roles/install-k8s/templates/kubeadm.yaml.j2
@@ -21,7 +21,7 @@ apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
 networking:
   serviceSubnet: "10.96.0.0/12"
-  podSubnet: "172.20.0.0/16"
+  podSubnet: "{{ pod_subnet }}"
   dnsDomain: "cluster.local"
 kubernetesVersion: "{{ release_marker }}"
 apiServer:


### PR DESCRIPTION
Changes:
1. Update Calico to use the latest release v3.24.5
2. Include option to install Calico using Tigera operator(default).
3. Introduce `installation_type` in `group_vars/all`  to select between operator/manifest based installation.
 