### PR TITLE
Generate crictl.yaml to configure crictl tool

### DIFF
--- a/roles/runtime/tasks/main.yaml
+++ b/roles/runtime/tasks/main.yaml
@@ -41,6 +41,11 @@
 
 - name: Common Prerequisites
   block:
+    - name: Generate crictl.yaml
+      template:
+        src: crictl/crictl.yaml.j2
+        dest: /etc/crictl.yaml
+        mode: '0644'
     - name: Install crictl - {{ critools_version }}
       unarchive:
         src: "https://github.com/kubernetes-sigs/cri-tools/releases/download/{{ critools_version }}/crictl-{{ critools_version }}-linux-ppc64le.tar.gz"

--- a/roles/runtime/templates/crictl/crictl.yaml.j2
+++ b/roles/runtime/templates/crictl/crictl.yaml.j2
@@ -1,0 +1,11 @@
+{% set containerd_sock = 'unix:///run/containerd/containerd.sock' %}
+{% set dockershim_sock = 'unix:///var/run/dockershim.sock' %}
+{% if 'containerd' == runtime %}
+runtime-endpoint: {{ containerd_sock }}
+image-endpoint: {{ containerd_sock }}
+{% else %}
+runtime-endpoint: {{ dockershim_sock }}
+image-endpoint: {{ dockershim_sock }}
+{% endif %}
+timeout: 2
+debug: false


### PR DESCRIPTION
**Requirement:** 

Ability to use crictl to manage the resources hosted on CRI. 
The default endpoints had been deprecated and are required to be set, which otherwise raises the following error upon running commands using crictl:
```
[root@kishen-k8s-master ~]# crictl pods
WARN[0000] runtime connect using default endpoints: [unix:///var/run/dockershim.sock unix:///run/containerd/containerd.sock unix:///run/crio/crio.sock unix:///var/run/cri-dockerd.sock]. 
As the default settings are now deprecated, you should set the endpoint instead.

E0118 15:04:19.571822  177722 remote_runtime.go:277] "ListPodSandbox with filter from runtime service failed" err="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial unix /var/run/dockershim.sock: connect: no such file or directory\"" filter="&PodSandboxFilter{Id:,State:nil,LabelSelector:map[string]string{},}"

FATA[0000] listing pod sandboxes: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial unix /var/run/dockershim.sock: connect: no such file or directory"
```
This PR aims at generating crictl.yaml, with the required fields  based on the installed container runtime. 

**Considerations:**
Docker and Containerd  are the only currently supported runtimes for the k8s infrastructure provisioned through the scope of existing playbooks.

**Reference:** 
https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/crictl.md#install-crictl