### PR TITLE
Cleanup: Remove deprecated field `container-runtime` and configure containerRuntimeEndpoint through kubeadm.yaml

### DIFF
--- a/roles/install-k8s/templates/kubeadm.yaml.j2
+++ b/roles/install-k8s/templates/kubeadm.yaml.j2
@@ -45,6 +45,9 @@ scheduler:
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 cgroupDriver: {{ cgroup_driver }}
+{% if (runtime is defined) and 'containerd' == runtime %}
+containerRuntimeEndpoint: "unix:///run/containerd/containerd.sock"
+{% endif %}
 ---
 apiVersion: kubeadm.k8s.io/v1beta3
 caCertPath: /etc/kubernetes/pki/ca.crt

--- a/roles/runtime/files/containerd/dropin.conf
+++ b/roles/runtime/files/containerd/dropin.conf
@@ -1,2 +1,0 @@
-[Service]
-Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --container-runtime-endpoint unix:///run/containerd/containerd.sock"

--- a/roles/runtime/tasks/containerd.yaml
+++ b/roles/runtime/tasks/containerd.yaml
@@ -20,17 +20,6 @@
     dest: /etc/containerd/config.toml
     mode: '0644'
 
-- name: Create a /etc/systemd/system/kubelet.service.d dir
-  file:
-    path: /etc/systemd/system/kubelet.service.d
-    state: directory
-    mode: '0755'
-
-- name: Create containerd drop-in file for kubelet service
-  copy:
-    src: containerd/dropin.conf
-    dest: /etc/systemd/system/kubelet.service.d/00-containerd-dropin.conf
-
 - name: Enable and Restart containerd
   systemd:
     name: containerd


### PR DESCRIPTION
**Changes in this PR:**
1.  Suppress the warning from kubelet `Flag --container-runtime has been deprecated, will be removed in 1.27 as the only valid value is 'remote'`
2. Set `containerRuntimeEndpoint` through kubeadm.yaml, rather than setting the same through `dropin.conf` as an extra argument during `kubeadm init`. 
