### PR TITLE
Add support for CRI-O container runtime. 

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -16,7 +16,7 @@ kubeconfig_path: kubeconfig
 ##### Runtime Configurations #####
 # cri-tools version
 critools_version: v1.26.0
-# valid runtimes: containerd
+# valid runtimes: containerd [default], crio.
 runtime: containerd
 # Docker runtime is deprecated after k8s v1.20 - https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/
 # This repo also supports installation with docker runtime as per the compatibility with k8s.

--- a/roles/install-k8s/tasks/main.yml
+++ b/roles/install-k8s/tasks/main.yml
@@ -41,6 +41,7 @@
 - name: Enable and start kubelet
   systemd:
     name: kubelet
+    daemon_reexec: true
     state: restarted
     enabled: yes
 
@@ -96,5 +97,5 @@
   with_items: "{{ groups['all'] }}"
 
 - name: kubeadm join
-  command: "{{ kubernetes_join_command }} {% if (runtime is defined) and 'containerd' == runtime %}--cri-socket /run/containerd/containerd.sock{% endif %}"
+  command: "{{ kubernetes_join_command }}"
   when: node_type == "worker"

--- a/roles/install-k8s/templates/kubeadm.yaml.j2
+++ b/roles/install-k8s/templates/kubeadm.yaml.j2
@@ -13,6 +13,8 @@ localAPIEndpoint:
 nodeRegistration:
 {% if (runtime is defined) and 'containerd' == runtime %}
   criSocket: "unix:///run/containerd/containerd.sock"
+{% elif (runtime is defined) and 'crio' == runtime %}
+  criSocket: "unix:///run/crio/crio.sock"
 {% endif %}
   kubeletExtraArgs:
     cgroup-driver: {{ cgroup_driver }}
@@ -47,6 +49,8 @@ kind: KubeletConfiguration
 cgroupDriver: {{ cgroup_driver }}
 {% if (runtime is defined) and 'containerd' == runtime %}
 containerRuntimeEndpoint: "unix:///run/containerd/containerd.sock"
+{% elif (runtime is defined) and 'crio' == runtime %}
+containerRuntimeEndpoint: "unix:///run/crio/crio.sock"
 {% endif %}
 ---
 apiVersion: kubeadm.k8s.io/v1beta3
@@ -61,4 +65,6 @@ kind: JoinConfiguration
 nodeRegistration:
 {% if (runtime is defined) and 'containerd' == runtime %}
   criSocket: "unix:///run/containerd/containerd.sock"
+{% elif (runtime is defined) and 'crio' == runtime %}
+  criSocket: "unix:///run/crio/crio.sock"
 {% endif %}

--- a/roles/runtime/files/crio/crio.service
+++ b/roles/runtime/files/crio/crio.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=Container Runtime Interface for OCI (CRI-O)
+Documentation=https://github.com/cri-o/cri-o
+Wants=network-online.target
+Before=kubelet.service
+After=network-online.target
+
+[Service]
+Type=notify
+EnvironmentFile=-/etc/sysconfig/crio
+Environment=GOTRACEBACK=crash
+ExecStart=/usr/local/bin/crio \
+          $CRIO_CONFIG_OPTIONS \
+          $CRIO_RUNTIME_OPTIONS \
+          $CRIO_STORAGE_OPTIONS \
+          $CRIO_NETWORK_OPTIONS \
+          $CRIO_METRICS_OPTIONS
+ExecReload=/bin/kill -s HUP $MAINPID
+TasksMax=infinity
+LimitNOFILE=1048576
+LimitNPROC=1048576
+LimitCORE=infinity
+OOMScoreAdjust=-999
+TimeoutStartSec=0
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+Alias=cri-o.service

--- a/roles/runtime/files/crio/policy.json
+++ b/roles/runtime/files/crio/policy.json
@@ -1,0 +1,7 @@
+{
+    "default": [
+        {
+            "type": "insecureAcceptAnything"
+        }
+    ]
+}

--- a/roles/runtime/tasks/crio.yaml
+++ b/roles/runtime/tasks/crio.yaml
@@ -1,0 +1,49 @@
+---
+- name: Install CRI-O and dependencies.
+  yum:
+    name:
+      - conmon
+      - runc
+    state: present
+    disable_gpg_check: true
+
+# TODO: Add support to generate a nix-build for ppc64le or add actions to generate a binary for cri-o
+- name: Download CRI-O.
+  unarchive:
+    src: "https://github.com/ppc64le-cloud/crio/raw/main/crio-1.26.tar.gz"
+    dest: "/usr/local/bin/"
+    remote_src: yes
+    extra_opts:
+      - --strip-components=1
+  retries: 3
+  delay: 5
+
+- name: Create /etc/containers dir.
+  file:
+    path: /etc/containers
+    state: directory
+    mode: '0755'
+
+# Reference: https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md
+# for policy refinement from the current "insecureAcceptAnything".
+- name: Define container pull policies on nodes.
+  copy:
+    src: crio/policy.json
+    dest: /etc/containers
+    mode: '0644'
+
+- name: Create the crio.service file on nodes.
+  copy:
+    src:  crio/crio.service
+    dest: /usr/lib/systemd/system/crio.service
+    mode: '0644'
+
+# TODO: Validate if the file needs to be created once when installations are possible.
+- name: Create /var/lib/crio/clean.shutdown file.
+  shell: mkdir -p /var/lib/crio && touch /var/lib/crio/clean.shutdown
+
+- name: Enable and Restart crio.
+  systemd:
+    name: crio
+    state: restarted
+    enabled: yes

--- a/roles/runtime/tasks/main.yaml
+++ b/roles/runtime/tasks/main.yaml
@@ -70,3 +70,7 @@
 - name: Install and Configure Runtime - Containerd
   import_tasks: containerd.yaml
   when: runtime == "containerd"
+
+- name: Install and Configure Runtime - CRI-O
+  import_tasks: crio.yaml
+  when: runtime == "crio"

--- a/roles/runtime/templates/crictl/crictl.yaml.j2
+++ b/roles/runtime/templates/crictl/crictl.yaml.j2
@@ -1,8 +1,12 @@
 {% set containerd_sock = 'unix:///run/containerd/containerd.sock' %}
+{% set crio_sock = 'unix:///run/crio/crio.sock' %}
 {% set dockershim_sock = 'unix:///var/run/dockershim.sock' %}
 {% if 'containerd' == runtime %}
 runtime-endpoint: {{ containerd_sock }}
 image-endpoint: {{ containerd_sock }}
+{% elif 'crio' == runtime %}
+runtime-endpoint: {{ crio_sock }}
+image-endpoint: {{ crio_sock }}
 {% else %}
 runtime-endpoint: {{ dockershim_sock }}
 image-endpoint: {{ dockershim_sock }}


### PR DESCRIPTION
Changes in this PR:
1. Support to use CRI-O as CRI for Kubernetes.

Follow up tasks : 
- [ ] Update ansble-submodule pointer in [kubetest2-plugins](https://github.com/ppc64le-cloud/kubetest2-plugins.git) repository.
- [ ] Update the [`containerd node throughput`](https://github.com/ppc64le-cloud/test-infra/blob/master/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml#L64) prow job to pick crio as runtime. - https://github.com/ppc64le-cloud/test-infra/pull/375
- [ ] Add support to build CRI-O binary through GH actions.
- [ ] Support for nix-builds on CRI-O's repository. (ref: [Add arm64 static builds to v1.20 release.](https://github.com/cri-o/cri-o/pull/4718/files))

Additional notes:
- The [binary](https://github.com/kishen-v/crio-ppc64le/blob/main/crio-1.26.tar.gz) for CRI-O needs to be moved from a personal account. WIP for generating builds through GH Actions.

___
 With CRI-O runtime.
```
[root@kishvisw-k8s-m ~]# kubectl get nodes -o wide
NAME             STATUS                     ROLES           AGE   VERSION                           INTERNAL-IP      EXTERNAL-IP   OS-IMAGE          KERNEL-VERSION           CONTAINER-RUNTIME
kishvisw-k8s-m   Ready,SchedulingDisabled   control-plane   52s   v1.27.0-beta.0.8+8b2dae57d4169e   192.168.161.21   <none>        CentOS Stream 8   4.18.0-408.el8.ppc64le   cri-o://1.26.0
kishvisw-k8s-w   Ready                      <none>          27s   v1.27.0-beta.0.8+8b2dae57d4169e   192.168.161.22   <none>        CentOS Stream 8   4.18.0-408.el8.ppc64le   cri-o://1.26.0
```
With Containerd runtime.
```
[root@kishvisw-k8s-m ~]# kubectl get nodes -o wide
NAME             STATUS                     ROLES           AGE   VERSION                           INTERNAL-IP      EXTERNAL-IP   OS-IMAGE          KERNEL-VERSION           CONTAINER-RUNTIME
kishvisw-k8s-m   Ready,SchedulingDisabled   control-plane   55s   v1.27.0-beta.0.8+8b2dae57d4169e   192.168.161.21   <none>        CentOS Stream 8   4.18.0-408.el8.ppc64le   containerd://1.6.18
kishvisw-k8s-w   Ready                      <none>          31s   v1.27.0-beta.0.8+8b2dae57d4169e   192.168.161.22   <none>        CentOS Stream 8   4.18.0-408.el8.ppc64le   containerd://1.6.18
```