### PR TITLE
Move from storage.googleapis.com to dl.k8s.io for downloads.

### DIFF
--- a/examples/containerd-cluster/extra-vars-k8s.json
+++ b/examples/containerd-cluster/extra-vars-k8s.json
@@ -1,6 +1,4 @@
 {
-  "s3_server": "storage.googleapis.com",
-  "bucket": "kubernetes-release",
   "directory": "release",
   "build_version": "v1.21.3",
   "release_marker": "release/v1.21.3",

--- a/group_vars/all
+++ b/group_vars/all
@@ -41,11 +41,10 @@ release_marker: ci/latest
 bootstrap_token: abcdef.0123456789abcdef
 kubelet_extra_args: ""
 
-# in the format of: https://storage.googleapis.com/{{ bucket }}/{{ directory }}/{{ build_version }}/kubernetes-client-linux-ppc64le.tar.gz
+# in the format of: https://dl.k8s.io/{{ directory }}/{{ build_version }}/kubernetes-client-linux-ppc64le.tar.gz
 # used for downloading the kubernetes bits
 # GCS web: https://gcsweb.k8s.io/gcs/kubernetes-release-dev/ci/
-s3_server: storage.googleapis.com
-bucket: k8s-release-dev
+s3_server: dl.k8s.io
 directory: ci
 build_version: v1.20.0-alpha.0.1402+d39214ade1d60c
 

--- a/hack/k8s-installer.sh
+++ b/hack/k8s-installer.sh
@@ -63,7 +63,6 @@ check_reachability()
 write_to_extravars()
 {
   sed -i \
-  -e "s/  \"bucket\": .*/  \"bucket\": \"$bucket\",/" \
   -e "s/  \"directory\": .*/  \"directory\": \"$directory\",/" \
   -e "s/  \"build_version\": .*/  \"build_version\": \"$version\",/" \
   -e "s/  \"release_marker\": .*/  \"release_marker\": \"$release_marker\",/" \
@@ -90,18 +89,16 @@ while getopts "ac:p:rw:y" opt; do
     a)
       alpha="true"
       echo "Fetching latest k8s Alpha CI version."
-      version=$(curl -s https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
+      version=$(curl -Ls https://dl.k8s.io/ci/latest.txt)
       release_marker="ci\/latest"
-      bucket="k8s-release-dev"
       directory="ci"
       write_to_extravars
       echo "Alpha release version to be used for cluster deployment: $version";;
     r)
       release="true"
       echo "Fetching latest k8s stable release version."
-      version=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
-      release_marker="release\/$version"
-      bucket="kubernetes-release"
+      version=$(curl -Ls https://dl.k8s.io/release/stable.txt)
+      release_marker="$version"
       directory="release"
       write_to_extravars
       echo "Stable release version to be used for cluster deployment: $version";;

--- a/roles/download-k8s/tasks/main.yml
+++ b/roles/download-k8s/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Extract the k8s bits
   unarchive:
-    src: "https://{{ s3_server }}/{{ bucket }}/{{ directory }}/{{ build_version }}/{{ item }}"
+    src: "https://{{ s3_server }}/{{ directory }}/{{ build_version }}/{{ item }}"
     dest: "/usr/local/bin/"
     remote_src: yes
     extra_opts:


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/2396#issue-953342920




Additional notes: Changes had been tested with both alpha and release versions for cluster deployments.