### PR TITLE
Generate download URL based on s3 bucket.

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -42,6 +42,7 @@ bootstrap_token: abcdef.0123456789abcdef
 kubelet_extra_args: ""
 
 # in the format of: https://dl.k8s.io/{{ directory }}/{{ build_version }}/kubernetes-client-linux-ppc64le.tar.gz
+# Eg: https://dl.k8s.io/ci/v1.28.0-alpha.1.48+039ae1edf5a71f/kubernetes-client-linux-ppc64le.tar.gz
 # used for downloading the kubernetes bits
 # GCS web: https://gcsweb.k8s.io/gcs/kubernetes-release-dev/ci/
 s3_server: dl.k8s.io
@@ -49,10 +50,11 @@ directory: ci
 build_version: v1.20.0-alpha.0.1402+d39214ade1d60c
 
 # For IBM s3 bucket:
-# https://s3.us-south.cloud-object-storage.appdomain.cloud/ci-builds/kubernetes/master/golang/master/d39214ade1d60c/kubernetes-client-linux-ppc64le.tar.gz
+# https://s3.us-south.cloud-object-storage.appdomain.cloud/{{ bucket }}/{{ directory }}/{{ build_version }}/kubernetes-client-linux-ppc64le.tar.gz
+# Eg: https://s3.us-south.cloud-object-storage.appdomain.cloud/ppc64le-ci-builds/kubernetes/master/golang/master/d39214ade1d60c/kubernetes-client-linux-ppc64le.tar.gz
 #
 # s3_server: s3.us-south.cloud-object-storage.appdomain.cloud
-# bucket: ci-builds
+bucket: ppc64le-ci-builds
 # directory: kubernetes/master/golang/master
 # build_version: d39214ade1d60c
 

--- a/roles/download-k8s/tasks/main.yml
+++ b/roles/download-k8s/tasks/main.yml
@@ -1,6 +1,15 @@
+- name: Generate download URL based on S3 server.
+  set_fact:
+    src_template: >-
+      {% if s3_server == 'dl.k8s.io' -%}
+        https://{{ s3_server }}/{{ directory }}/{{ build_version }}
+      {%- else -%}
+        https://{{ s3_server }}/{{ bucket }}/{{ directory }}/{{ build_version }}
+      {%- endif %}
+
 - name: Extract the k8s bits
   unarchive:
-    src: "https://{{ s3_server }}/{{ directory }}/{{ build_version }}/{{ item }}"
+    src: "{{ src_template }}/{{ item }}"
     dest: "/usr/local/bin/"
     remote_src: yes
     extra_opts:


### PR DESCRIPTION
Fixes: https://github.com/ppc64le-cloud/k8s-ansible/issues/57

Verified with downloads from both `dl.k8s.io` and `s3.us-south.cloud-object-storage.appdomain.cloud`

---
For s3.us-south.cloud-object-storage.appdomain.cloud (Partial o/p captured.)
```
TASK [download-k8s : Debug bucket variable] ********************************************************
ok: [192.168.159.220] => {
    "src_template": "https://s3.us-south.cloud-object-storage.appdomain.cloud/ppc64le-ci-builds/kubernetes/master/golang/master/7935006af29"
}
ok: [192.168.159.219] => {
    "src_template": "https://s3.us-south.cloud-object-storage.appdomain.cloud/ppc64le-ci-builds/kubernetes/master/golang/master/7935006af29"
}

TASK [download-k8s : Extract the k8s bits] *********************************************************
ok: [192.168.159.220] => (item=kubernetes-test-linux-ppc64le.tar.gz)
ok: [192.168.159.219] => (item=kubernetes-test-linux-ppc64le.tar.gz)
changed: [192.168.159.220] => (item=kubernetes-client-linux-ppc64le.tar.gz)
changed: [192.168.159.219] => (item=kubernetes-client-linux-ppc64le.tar.gz
```
For dl.k8s.io (Partial o/p captured.)
```

TASK [download-k8s : Debug bucket variable] ********************************************************
ok: [192.168.159.220] => {
    "src_template": "https://dl.k8s.io/ci/v1.28.0-alpha.1.48+039ae1edf5a71f"
}
ok: [192.168.159.219] => {
    "src_template": "https://dl.k8s.io/ci/v1.28.0-alpha.1.48+039ae1edf5a71f"
}

TASK [download-k8s : Extract the k8s bits] *********************************************************
changed: [192.168.159.220] => (item=kubernetes-test-linux-ppc64le.tar.gz)
changed: [192.168.159.219] => (item=kubernetes-test-linux-ppc64le.tar.gz)
changed: [192.168.159.219] => (item=kubernetes-client-linux-ppc64le.tar.gz)
changed: [192.168.159.220] => (item=kubernetes-client-linux-ppc64le.tar.gz)
```