### PR TITLE
Fetch containerd binary from GitHub.

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -18,6 +18,7 @@ kubeconfig_path: kubeconfig
 critools_version: v1.26.0
 # valid runtimes: containerd [default], crio.
 runtime: containerd
+containerd_version: 1.7.2
 pause_container_image: registry.k8s.io/pause:3.9
 # Docker runtime is deprecated after k8s v1.20 - https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/
 # This repo also supports installation with docker runtime as per the compatibility with k8s.

--- a/group_vars/all
+++ b/group_vars/all
@@ -16,6 +16,7 @@ kubeconfig_path: kubeconfig
 ##### Runtime Configurations #####
 # cri-tools version
 critools_version: v1.26.0
+runc_version: 1.1.7
 # valid runtimes: containerd [default], crio.
 runtime: containerd
 containerd_version: 1.7.2

--- a/roles/runtime/tasks/containerd.yaml
+++ b/roles/runtime/tasks/containerd.yaml
@@ -4,7 +4,6 @@
     name:
       - device-mapper-persistent-data
       - lvm2
-      - runc
     state: present
     disable_gpg_check: true
 

--- a/roles/runtime/tasks/containerd.yaml
+++ b/roles/runtime/tasks/containerd.yaml
@@ -1,12 +1,26 @@
 ---
-- name: Install containerd
+- name: Install containerd dependencies
   yum:
     name:
-      - containerd
       - device-mapper-persistent-data
       - lvm2
+      - runc
     state: present
     disable_gpg_check: true
+
+- name: Download and set up containerd.
+  unarchive:
+    src: "https://github.com/containerd/containerd/releases/download/v{{ containerd_version }}/containerd-{{ containerd_version }}-linux-ppc64le.tar.gz"
+    dest: "/usr/local"
+    remote_src: yes
+  retries: 3
+  delay: 5
+
+- name: Create the containerd.service file on nodes.
+  get_url:
+    url: "https://raw.githubusercontent.com/containerd/containerd/main/containerd.service"
+    dest: /usr/lib/systemd/system/containerd.service
+    mode: '0755'
 
 - name: Create a /etc/containerd dir
   file:

--- a/roles/runtime/tasks/crio.yaml
+++ b/roles/runtime/tasks/crio.yaml
@@ -3,7 +3,6 @@
   yum:
     name:
       - conmon
-      - runc
     state: present
     disable_gpg_check: true
 

--- a/roles/runtime/tasks/main.yaml
+++ b/roles/runtime/tasks/main.yaml
@@ -52,13 +52,6 @@
         dest: "/usr/local/bin/"
         remote_src: yes
 
-    - name: Add Public Docker repository
-      yum_repository:
-        name: public-docker
-        description: Public Docker Repository
-        baseurl: https://download.docker.com/linux/centos/8/ppc64le/stable/
-        gpgcheck: no
-
     - name: Install iptables
       yum:
         name: iptables

--- a/roles/runtime/tasks/main.yaml
+++ b/roles/runtime/tasks/main.yaml
@@ -56,6 +56,12 @@
       yum:
         name: iptables
 
+    - name: Install container runtime - runc
+      get_url:
+        url: "https://github.com/opencontainers/runc/releases/download/v{{ runc_version }}/runc.ppc64le"
+        dest: /usr/bin/runc
+        mode: '0755'
+
 - name: Install and Configure Runtime - Docker
   import_tasks: docker.yaml
   when: runtime == "docker"


### PR DESCRIPTION
The metadata on the docker repository for ppc64le seems to be missing, which is causing an error in the periodic jobs. 
This PR has required changes to retrieve the binary from GitHub. 

Fixes: #59 