### PR TITLE
Add k8s-node-remote playbook

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -66,3 +66,11 @@ calico_installation_type: manifest
 
 ##### List of images to be prepulled #####
 prepull_images: []
+
+##### ETCD version #####
+etcd_version: v3.5.9
+
+##### Bridge CNI Configurations #####
+cni_plugins_version: v1.3.0
+cni_plugins_url: https://github.com/containernetworking/plugins/releases/download
+cni_plugins_tarball: "cni-plugins-linux-{{ ansible_architecture }}-{{ cni_plugins_version }}.tgz"

--- a/k8s-node-remote.yml
+++ b/k8s-node-remote.yml
@@ -1,0 +1,10 @@
+- name: Install prerequisites and run e2e node tests
+  hosts:
+    - masters
+  roles:
+    - disable-swap-selinux
+    - install-bridge-cni
+    - install-etcd
+    - runtime
+    - download-k8s
+    - k8s-node

--- a/roles/disable-swap-selinux/tasks/main.yml
+++ b/roles/disable-swap-selinux/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: Disable SWAP since kubernetes can't work with swap enabled (1/2)
+  shell: |
+    swapoff -a
+
+- name: Disable SWAP in fstab since kubernetes can't work with swap enabled (2/2)
+  replace:
+    path: /etc/fstab
+    regexp: '^([^#].*?\sswap\s+sw\s+.*)$'
+    replace: '# \1'
+
+- name: Disable SELinux
+  shell: |
+    setenforce 0
+    sed -i 's/^SELINUX=.*/SELINUX=permissive/g' /etc/selinux/config

--- a/roles/install-bridge-cni/tasks/main.yml
+++ b/roles/install-bridge-cni/tasks/main.yml
@@ -1,0 +1,26 @@
+- name: Create cni directory
+  file:
+    path: /opt/cni/bin
+    state: directory
+
+- name: Download and setup cni plugins
+  unarchive:
+    src: "{{ cni_plugins_url }}/{{ cni_plugins_version }}/{{ cni_plugins_tarball }}"
+    dest: "/opt/cni/bin"
+    remote_src: yes
+    extra_opts:
+      - --strip-components=1
+  retries: 3
+  delay: 5
+
+- name: Create a /etc/cni/net.d dir
+  file:
+    path: /etc/cni/net.d
+    state: directory
+    mode: '0755'
+
+- name: Generate 10-bridge-net.conflist file
+  template:
+    src: 10-bridge-net.conflist.j2
+    dest: /etc/cni/net.d/10-bridge-net.conflist
+    mode: '0644'

--- a/roles/install-bridge-cni/templates/10-bridge-net.conflist.j2
+++ b/roles/install-bridge-cni/templates/10-bridge-net.conflist.j2
@@ -1,0 +1,33 @@
+{
+ "cniVersion": "1.0.0",
+ "name": "bridge-net",
+ "plugins": [
+   {
+     "type": "bridge",
+     "bridge": "cni0",
+     "isGateway": true,
+     "ipMasq": true,
+     "promiscMode": true,
+     "ipam": {
+       "type": "host-local",
+       "ranges": [
+         [{
+           "subnet": "10.88.0.0/16"
+         }],
+         [{
+           "subnet": "2001:db8:4860::/64"
+         }]
+       ],
+       "routes": [
+         { "dst": "0.0.0.0/0" },
+         { "dst": "::/0" }
+       ]
+     }
+   },
+   {
+     "type": "portmap",
+     "capabilities": {"portMappings": true},
+     "externalSetMarkChain": "KUBE-MARK-MASQ"
+   }
+ ]
+}

--- a/roles/install-etcd/files/etcd.service
+++ b/roles/install-etcd/files/etcd.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Etcd Server
+
+[Service]
+ExecStart=/usr/local/bin/etcd
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/install-etcd/tasks/main.yml
+++ b/roles/install-etcd/tasks/main.yml
@@ -1,0 +1,21 @@
+- name: Download and setup etcd
+  unarchive:
+    src: "https://storage.googleapis.com/etcd/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-{{ ansible_architecture }}.tar.gz"
+    dest: "/usr/local/bin"
+    remote_src: yes
+    extra_opts:
+      - --strip-components=1
+  retries: 3
+  delay: 5
+
+- name: Create the etcd.service file on nodes.
+  copy:
+    src: etcd.service
+    dest: /etc/systemd/system/etcd.service
+    mode: '0644'
+
+- name: Enable and start etcd server on node
+  systemd:
+    name: etcd
+    state: started
+    enabled: True

--- a/roles/k8s-node/tasks/main.yml
+++ b/roles/k8s-node/tasks/main.yml
@@ -1,8 +1,45 @@
-- name: Disable SELinux
-  selinux:
-    state: disabled
+- name: change systemd cgroup driver to default cgroupfs
+  replace:
+    path: /etc/containerd/config.toml
+    regexp: 'SystemdCgroup = true'
+    replace: 'SystemdCgroup = false'
 
-- name: Run the node-e2e tests
-  command: ginkgo --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]" --nodes=8 /usr/local/bin/e2e_node.test -- --k8s-bin-dir /usr/local/bin --test.timeout=1h5m0s --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --cgroup-driver={{ cgroup_driver }}"
-  args:
-    chdir: /tmp
+- name: Restart containerd service
+  systemd:
+    name: containerd
+    state: restarted
+
+- name: Install prereq packages
+  yum:
+    name: "{{ packages }}"
+    state: present
+  vars:
+    packages:
+      - git
+      - make
+      - gcc
+
+- name: Capture the commit ID
+  set_fact:
+    commit: "{{ build_version | regex_search('(?<=\\+)(.*)') }}"
+
+- name: Clone a kubernetes github repo
+  git:
+    repo: https://github.com/kubernetes/kubernetes
+    dest: /kubernetes/
+    version: "{{ commit }}"
+    clone: yes
+    update: yes
+
+- name: Create a shell script
+  copy:
+    content: |
+      #!/bin/bash
+      set -o errexit
+
+      echo 'This is a script to run e2e-node tests'
+      pushd /kubernetes
+        make test-e2e-node FOCUS="\[NodeConformance\]" SKIP="\[Flaky\]|\[Slow\]|\[Serial\]"
+      popd
+    dest: /make-test-e2e-node.sh
+    mode: '0755'


### PR DESCRIPTION
This is to add roles for installing `etcd` and `bridge cni` on a node.
Will be used for setting up CI job that runs e2e_node tests of k8s repository.

https://prow.ppc64le-cloud.cis.ibm.net/view/gs/ppc64le-kubernetes/logs/test-periodic-kubernetes-containerd-e2e-node-tests-ppc64le/1717518352693334016
though above job has failed at the stage of using tester, it has successfully passed the phase of using these roles to setup etcd, bridge cni and containerd.

References: https://github.com/etcd-io/etcd/releases
https://github.com/kubernetes/kubernetes/blob/master/hack/local-up-cluster.sh#L1168-L1234