### PR TITLE
Make focus and skip in k8s-node task as variable

### DIFF
--- a/roles/k8s-node/tasks/main.yml
+++ b/roles/k8s-node/tasks/main.yml
@@ -37,9 +37,11 @@
       #!/bin/bash
       set -o errexit
 
+      focus=${FOCUS:-"\[NodeConformance\]"}
+      skip=${SKIP-"\[Flaky\]|\[Slow\]|\[Serial\]"}
       echo 'This is a script to run e2e-node tests'
       pushd /kubernetes
-        make test-e2e-node FOCUS="\[NodeConformance\]" SKIP="\[Flaky\]|\[Slow\]|\[Serial\]"
+        make test-e2e-node FOCUS=${focus} SKIP=${skip}
       popd
     dest: /make-test-e2e-node.sh
     mode: '0755'


### PR DESCRIPTION
Having the `skip` and `focus` variables open to send from outside, will enable easy test execution when `kubetest2 tf ` is used.