### PR TITLE
Set SELinux to permissive mode to enable deployment of CNI with cri-o.

### DIFF
--- a/roles/disable-swap-selinux/tasks/main.yml
+++ b/roles/disable-swap-selinux/tasks/main.yml
@@ -8,7 +8,7 @@
     regexp: '^([^#].*?\sswap\s+sw\s+.*)$'
     replace: '# \1'
 
-- name: Disable SELinux
-  shell: |
-    setenforce 0
-    sed -i 's/^SELINUX=.*/SELINUX=permissive/g' /etc/selinux/config
+- name: Set SELinux to permissive mode
+  ansible.posix.selinux:
+    state: permissive
+    policy: targeted

--- a/roles/install-k8s/tasks/main.yml
+++ b/roles/install-k8s/tasks/main.yml
@@ -6,15 +6,9 @@
   command: ethtool --offload {{ ansible_default_ipv4['interface'] }} tx-checksumming off
   when: ansible_default_ipv4['interface'] is defined
 
-- name: Disable SWAP since kubernetes can't work with swap enabled (1/2)
-  shell: |
-    swapoff -a
-
-- name: Disable SWAP in fstab since kubernetes can't work with swap enabled (2/2)
-  replace:
-    path: /etc/fstab
-    regexp: '^([^#].*?\sswap\s+sw\s+.*)$'
-    replace: '# \1'
+- name: Disable SELinux and disable SWAP in fstab
+  include_role:
+    name: disable-swap-selinux
 
 # PowerVS has default domainname set as .power-iaas.cloud.ibm.com which is not present in the cloud
 - name: Remove domainname from the hostname


### PR DESCRIPTION
This PR contains the changes to enable the CNI pods to run, which didn't start earlier due to lack of permissions enforced by SELinux. The SELinux policy is now set to "permissive" from "enforced".

```
[root@kishen-k8s-1 ~]# kubectl get pods -A
NAMESPACE     NAME                                       READY   STATUS    RESTARTS     AGE
kube-system   calico-kube-controllers-7c968b5878-rtg9d   1/1     Running   0            89m
kube-system   calico-node-bwcdp                          1/1     Running   0            2m37s
kube-system   calico-node-vth2n                          1/1     Running   0            2m37s
kube-system   coredns-76f75df574-bd6lh                   0/1     Error     1 (2s ago)   89m
kube-system   coredns-76f75df574-zb8zr                   0/1     Error     1 (2s ago)   89m
kube-system   etcd-kishen-k8s-1                          1/1     Running   9            89m
kube-system   kube-apiserver-kishen-k8s-1                1/1     Running   2            89m
kube-system   kube-controller-manager-kishen-k8s-1       1/1     Running   2            89m
kube-system   kube-proxy-skm65                           1/1     Running   0            89m
kube-system   kube-proxy-swzmv                           1/1     Running   0            89m
kube-system   kube-scheduler-kishen-k8s-1                1/1     Running   2            89m

[root@kishen-k8s-1 ~]# sestatus
SELinux status:                 enabled
SELinuxfs mount:                /sys/fs/selinux
SELinux root directory:         /etc/selinux
Loaded policy name:             targeted
Current mode:                   enforcing
Mode from config file:          enforcing
Policy MLS status:              enabled
Policy deny_unknown status:     allowed
Memory protection checking:     actual (secure)
Max kernel policy version:      33
```
```
[root@kishen-k8s-1 ~]# kubectl get pods -A
NAMESPACE     NAME                                       READY   STATUS    RESTARTS   AGE
kube-system   calico-kube-controllers-7c968b5878-rtg9d   1/1     Running   0          88m
kube-system   calico-node-bwcdp                          1/1     Running   0          92s
kube-system   calico-node-vth2n                          1/1     Running   0          92s
kube-system   coredns-76f75df574-bd6lh                   1/1     Running   0          88m
kube-system   coredns-76f75df574-zb8zr                   1/1     Running   0          88m
kube-system   etcd-kishen-k8s-1                          1/1     Running   9          88m
kube-system   kube-apiserver-kishen-k8s-1                1/1     Running   2          88m
kube-system   kube-controller-manager-kishen-k8s-1       1/1     Running   2          88m
kube-system   kube-proxy-skm65                           1/1     Running   0          88m
kube-system   kube-proxy-swzmv                           1/1     Running   0          88m
kube-system   kube-scheduler-kishen-k8s-1                1/1     Running   2          88m
[root@kishen-k8s-1 ~]# sestatus
SELinux status:                 enabled
SELinuxfs mount:                /sys/fs/selinux
SELinux root directory:         /etc/selinux
Loaded policy name:             targeted
Current mode:                   permissive
Mode from config file:          permissive
Policy MLS status:              enabled
Policy deny_unknown status:     allowed
Memory protection checking:     actual (secure)
Max kernel policy version:      33
```
