### PR TITLE
Use cri-o from source repository.

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -20,6 +20,7 @@ runc_version: 1.1.10
 # valid runtimes: containerd [default], crio.
 runtime: containerd
 containerd_version: 1.7.9
+crio_version: 1.28.1
 pause_container_image: registry.k8s.io/pause:3.9
 
 cgroup_driver: systemd

--- a/install-k8s-perf.yml
+++ b/install-k8s-perf.yml
@@ -1,7 +1,7 @@
 - hosts: all
   tasks:
     - set_fact:
-        prepull_images: "{{ prepull_images + ['registry.k8s.io/pause:3.1'] }}"
+        prepull_images: "{{ prepull_images + ['registry.k8s.io/pause:3.9'] }}"
 
 - name: Install Runtime and Kubernetes
   hosts:

--- a/roles/runtime/tasks/crio.yaml
+++ b/roles/runtime/tasks/crio.yaml
@@ -6,14 +6,14 @@
     state: present
     disable_gpg_check: true
 
-# TODO: Add support to generate a nix-build for ppc64le or add actions to generate a binary for cri-o
 - name: Download CRI-O.
   unarchive:
-    src: "https://github.com/ppc64le-cloud/crio/raw/main/crio-1.26.tar.gz"
+    src: "https://github.com/cri-o/cri-o/releases/download/v{{ crio_version }}/cri-o.ppc64le.v{{ crio_version }}.tar.gz"
     dest: "/usr/local/bin/"
     remote_src: yes
+    include: cri-o/bin
     extra_opts:
-      - --strip-components=1
+      - --strip-components=2
   retries: 3
   delay: 5
 


### PR DESCRIPTION
As cri-o builds for ppc64le are made available in the repository, this PR contains changes to make use of the same. The current version to be used is 1.28.1

```
[root@kishen-k8s-1 ~]# kubectl get pods -A
NAMESPACE     NAME                                       READY   STATUS    RESTARTS   AGE
kube-system   calico-kube-controllers-7c968b5878-2kvbd   1/1     Running   0          4m9s
kube-system   calico-node-67xcd                          1/1     Running   0          43s
kube-system   calico-node-r64fc                          1/1     Running   0          43s
kube-system   coredns-76f75df574-d7txc                   1/1     Running   0          4m16s
kube-system   coredns-76f75df574-wl2b6                   1/1     Running   0          4m16s
kube-system   etcd-kishen-k8s-1                          1/1     Running   1          4m29s
kube-system   kube-apiserver-kishen-k8s-1                1/1     Running   1          4m29s
kube-system   kube-controller-manager-kishen-k8s-1       1/1     Running   1          4m29s
kube-system   kube-proxy-bwmzm                           1/1     Running   0          4m15s
kube-system   kube-proxy-ptshl                           1/1     Running   0          4m17s
kube-system   kube-scheduler-kishen-k8s-1                1/1     Running   1          4m29s


[root@kishen-k8s-1 ~]# kubectl get nodes -o wide
NAME           STATUS                     ROLES           AGE     VERSION                             INTERNAL-IP    EXTERNAL-IP   OS-IMAGE          KERNEL-VERSION           CONTAINER-RUNTIME
kishen-k8s-1   Ready,SchedulingDisabled   control-plane   4m49s   v1.30.0-alpha.0.24+f2e85bc36449fd   9.114.99.212   <none>        CentOS Stream 8   4.18.0-365.el8.ppc64le   cri-o://1.28.1
kishen-k8s-2   Ready                      <none>          4m30s   v1.30.0-alpha.0.24+f2e85bc36449fd   9.114.99.242   <none>        CentOS Stream 8   4.18.0-365.el8.ppc64le   cri-o://1.28.1
```