### PR TITLE
Remove download-k8s role from k8s-node-remote playbook

### DIFF
--- a/k8s-node-remote.yml
+++ b/k8s-node-remote.yml
@@ -6,5 +6,4 @@
     - install-bridge-cni
     - install-etcd
     - runtime
-    - download-k8s
     - k8s-node


### PR DESCRIPTION
`download-k8s` role isn't required here.
The binaries are built when we run the make command here at 
https://github.com/ppc64le-cloud/k8s-ansible/blob/master/roles/k8s-node/tasks/main.yml#L46 thus we don't need a prerequisite for downloading binaries.