### PR TITLE
Adding KUBE_ROOT value for k8s-node task

### DIFF
--- a/roles/k8s-node/tasks/main.yml
+++ b/roles/k8s-node/tasks/main.yml
@@ -39,6 +39,7 @@
 
       focus=${FOCUS:-"\[NodeConformance\]"}
       skip=${SKIP-"\[Flaky\]|\[Slow\]|\[Serial\]"}
+      export KUBE_ROOT=/
       echo 'This is a script to run e2e-node tests'
       pushd /kubernetes
         make test-e2e-node FOCUS=${focus} SKIP=${skip}


### PR DESCRIPTION
This change https://github.com/kubernetes/kubernetes/pull/123647 in k8s upstream has started introducing failure to job `periodic-kubernetes-containerd-e2e-node-tests-ppc64le` https://prow.ppc64le-cloud.cis.ibm.net/job-history/gs/ppc64le-kubernetes/logs/periodic-kubernetes-containerd-e2e-node-tests-ppc64le
```
 I0303 18:26:52.001612   37232 build.go:59] Building k8s binaries...
F0303 18:26:52.001656   37232 run_local.go:49] Failed to build the dependencies: unable to build cgo targets : failed to locate kubernetes root directory could not find kubernetes source root directory
exit status 255 
```

Export of `KUBE_ROOT` value avoids this failure.
