### PR TITLE
Add kubelet flag to resolve summary test failure.

### DIFF
--- a/roles/k8s-node/tasks/main.yml
+++ b/roles/k8s-node/tasks/main.yml
@@ -42,7 +42,8 @@
       export KUBE_ROOT=/
       echo 'This is a script to run e2e-node tests'
       pushd /kubernetes
-        make test-e2e-node FOCUS=${focus} SKIP=${skip}
+        test_args='--kubelet-flags="--runtime-cgroups=/system.slice/containerd.service"'
+        TEST_ARGS=${test_args} make test-e2e-node FOCUS=${focus} SKIP=${skip}
       popd
     dest: /make-test-e2e-node.sh
     mode: '0755'


### PR DESCRIPTION
The test https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/summary_test.go#L57 fails consistently on ppc64le. Pass `kubelet-flags="--runtime-cgroups=/system.slice/containerd.service` to fix it.