### PR TITLE
Define tar bundles under group-vars to have control

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -32,6 +32,10 @@ registry_mirrors:
   - https://registry-1.docker.io
 
 ##### Kubernetes Configurations #####
+k8s_tar_bundles:
+  - kubernetes-test-linux-ppc64le.tar.gz
+  - kubernetes-client-linux-ppc64le.tar.gz
+  - kubernetes-server-linux-ppc64le.tar.gz
 apiserver_port: 992
 cluster_name: "k8s-cluster-1"
 powervs_dns_zone: "k8s.test"

--- a/roles/download-k8s/tasks/main.yml
+++ b/roles/download-k8s/tasks/main.yml
@@ -14,9 +14,6 @@
     remote_src: yes
     extra_opts:
       - --strip-components=3
-  with_items:
-    - kubernetes-test-linux-ppc64le.tar.gz
-    - kubernetes-client-linux-ppc64le.tar.gz
-    - kubernetes-server-linux-ppc64le.tar.gz
+  with_items: "{{ k8s_tar_bundles }}"
   retries: 3
   delay: 5


### PR DESCRIPTION
To improve flexibility of having control over the k8s tarballs that are downloaded.

<img width="1267" alt="image" src="https://github.com/user-attachments/assets/59aa30bd-cae9-455d-ab57-6e52a0e94986">
