### PR TITLE
Task to import container images to nodes

### DIFF
--- a/roles/download-k8s/tasks/main.yml
+++ b/roles/download-k8s/tasks/main.yml
@@ -17,3 +17,15 @@
   with_items: "{{ k8s_tar_bundles }}"
   retries: 3
   delay: 5
+
+- name: Import container images
+  shell: |
+    export ARCH={{ ansible_architecture }}
+    ctr -n k8s.io images import "/usr/local/bin/{{ item }}.tar"
+    ctr -n k8s.io images ls -q | grep -e {{ item }} | xargs -L 1 -I '{}' /bin/bash -c 'ctr -n k8s.io images tag "{}" "$(echo "{}" | sed s/-'$ARCH':/:/)"'
+  with_items:
+    - kube-apiserver
+    - kube-controller-manager
+    - kubectl
+    - kube-proxy
+    - kube-scheduler


### PR DESCRIPTION
This task added would import the ctr images from .tar files in /usr/local/bin.

In the below test run, have displayed the verbose of `kubeadm init` and made sure images are not pulled and used from existing ones in runtime.
Test Run: https://storage.googleapis.com/ppc64le-kubernetes/logs/test-periodic-kubernetes-containerd-conformance-test-ppc64le/1849756631768764416/build-log.txt