### PR TITLE
Add pre-check to conditionally remove control-plane taint

### DIFF
--- a/roles/install-nfs/tasks/main.yaml
+++ b/roles/install-nfs/tasks/main.yaml
@@ -57,8 +57,14 @@
   vars:
     nfs_server: "{{ nfs_server_ip.stdout }}"
 
-- name: remove taint
+- name: Check if the control-plane taint exists
+  shell: "kubectl get nodes -o wide | grep 'node-role.kubernetes.io/control-plane'"
+  register: taint_check
+  ignore_errors: true
+
+- name: Remove control-plane taint if present
   command: "kubectl taint nodes --all node-role.kubernetes.io/control-plane-"
+  when: taint_check.rc == 0
 
 - name: Apply RBAC configuration
   command: kubectl create -f /tmp/rbac.yaml


### PR DESCRIPTION
Conditionally remove control-plane taint to avoid errors when taint is absent

- Added a pre-check to verify the existence of the 'node-role.kubernetes.io/control-plane' taint using a shell command.
- Updated the taint removal logic to execute only if the taint is present, preventing unnecessary errors.
