### PR TITLE
Add k8s_branch variable required for k8s_ut role

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -45,6 +45,7 @@ extra_cert: "{{ cluster_name }}-master.{{ powervs_dns_zone }}"
 release_marker: ci/latest
 bootstrap_token: abcdef.0123456789abcdef
 kubelet_extra_args: ""
+k8s_branch: master
 
 # in the format of: https://dl.k8s.io/{{ directory }}/{{ build_version }}/kubernetes-client-linux-ppc64le.tar.gz
 # Eg: https://dl.k8s.io/ci/v1.28.0-alpha.1.48+039ae1edf5a71f/kubernetes-client-linux-ppc64le.tar.gz

--- a/roles/k8s-ut/tasks/main.yml
+++ b/roles/k8s-ut/tasks/main.yml
@@ -26,6 +26,7 @@
       export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
       export LOG_LEVEL=4
       export ARTIFACTS=~/artifacts
+      git checkout {{ k8s_branch }}
       make test KUBE_RACE=-race
       popd
       EOF


### PR DESCRIPTION
This option is required when we wish to run the k8s UT against a specific release branch.