### PR TITLE
use 6443 for apiserver

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -36,7 +36,7 @@ k8s_tar_bundles:
   - kubernetes-test-linux-ppc64le.tar.gz
   - kubernetes-client-linux-ppc64le.tar.gz
   - kubernetes-server-linux-ppc64le.tar.gz
-apiserver_port: 992
+apiserver_port: 6443
 cluster_name: "k8s-cluster-1"
 powervs_dns_zone: "k8s.test"
 pod_subnet: 172.20.0.0/16


### PR DESCRIPTION
Switching to the default port which is now available in the powervs environment.