### PR TITLE
Include option to setup a multinode cluster

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -37,6 +37,7 @@ k8s_tar_bundles:
   - kubernetes-client-linux-ppc64le.tar.gz
   - kubernetes-server-linux-ppc64le.tar.gz
 apiserver_port: 6443
+loadbalancer: default.com
 cluster_name: "k8s-cluster-1"
 powervs_dns_zone: "k8s.test"
 pod_subnet: 172.20.0.0/16

--- a/group_vars/all
+++ b/group_vars/all
@@ -37,7 +37,7 @@ k8s_tar_bundles:
   - kubernetes-client-linux-ppc64le.tar.gz
   - kubernetes-server-linux-ppc64le.tar.gz
 apiserver_port: 6443
-loadbalancer: default.com
+loadbalancer: ""
 cluster_name: "k8s-cluster-1"
 powervs_dns_zone: "k8s.test"
 pod_subnet: 172.20.0.0/16

--- a/roles/install-calico/tasks/calico-manifest.yaml
+++ b/roles/install-calico/tasks/calico-manifest.yaml
@@ -3,14 +3,17 @@
     url: "https://raw.githubusercontent.com/projectcalico/calico/{{ calico_version }}/manifests/calico.yaml"
     dest: /tmp/calico.yaml
     mode: '0755'
+  when: inventory_hostname == groups['masters'][0]
 
 - name: Set veth_mtu
   replace:
     path: /tmp/calico.yaml
     regexp: 'veth_mtu\:.*'
     replace: 'veth_mtu: "{{ calico_mtu }}"'
+  when: inventory_hostname == groups['masters'][0]
 
 - name: Set up Calico CNI from manifest
   command: kubectl create -f /tmp/calico.yaml
   environment:
     KUBECONFIG: /etc/kubernetes/admin.conf
+  when: inventory_hostname == groups['masters'][0]

--- a/roles/install-k8s/tasks/main.yml
+++ b/roles/install-k8s/tasks/main.yml
@@ -60,13 +60,15 @@
     dest: /root/kubeadm.yaml
     mode: '0644'
 
-- name: kubeadm init for a single control-plane node
-  command: "kubeadm init --config /root/kubeadm.yaml"
-  when: groups['masters']|length < 2 and node_type == "master"
+- name: Perform kubeadm init on the control plane node based on LB configuration.
+  command: >
+    {% if loadbalancer == '' -%}
+      kubeadm init --config /root/kubeadm.yaml
+    {%- else -%}
+      kubeadm init --config /root/kubeadm.yaml --upload-certs
+    {%- endif %}
+  when: inventory_hostname == groups['masters'][0]
 
-- name: kubeadm init for multi control-plane node
-  command: "kubeadm init --config /root/kubeadm.yaml --upload-certs"
-  when: groups['masters']|length > 1 and inventory_hostname == groups['masters'][0]
 
 - name: generate join command for HA cluster
   environment:
@@ -82,7 +84,7 @@
   set_fact:
     kubernetes_cp_join_command: >
       {{ kubernetes_cp_join_command_result.stdout }}
-  when: kubernetes_cp_join_command_result.stdout is defined
+  when: kubernetes_cp_join_command_result.stdout is defined and groups['masters']|length > 1
   delegate_to: "{{ item }}"
   delegate_facts: true
   with_items: "{{ groups['all'] }}"

--- a/roles/install-k8s/tasks/main.yml
+++ b/roles/install-k8s/tasks/main.yml
@@ -4,7 +4,7 @@
 # Follow up task to remove this in future https://jsw.ibm.com/browse/POWERCLOUD-34
 - name: Disable tx-checksumming on default network interface
   command: ethtool --offload {{ ansible_default_ipv4['interface'] }} tx-checksumming off
-  when: 
+  when:
     - ansible_default_ipv4['interface'] is defined
     - ansible_architecture == 'ppc64le'
 
@@ -13,7 +13,7 @@
     name: disable-swap-selinux
 
 # PowerVS has default domainname set as .power-iaas.cloud.ibm.com which is not present in the cloud
-- name: Remove domainname from the hostname
+- name: Remove domain name from the hostname
   shell: |
     hostnamectl set-hostname $(hostname | cut -d "." -f1)
 
@@ -29,7 +29,7 @@
       - iptables
   when: ansible_pkg_mgr == 'yum'
 
-- name: Install prereq Ubuntu packages 
+- name: Install prereq Ubuntu packages
   apt:
     name: "{{ packages }}"
     state: present
@@ -60,15 +60,43 @@
     dest: /root/kubeadm.yaml
     mode: '0644'
 
-- name: kubeadm init
+- name: kubeadm init for a single control-plane node
   command: "kubeadm init --config /root/kubeadm.yaml"
-  when: node_type == "master"
+  when: groups['masters']|length < 2 and node_type == "master"
+
+- name: kubeadm init for multi control-plane node
+  command: "kubeadm init --config /root/kubeadm.yaml --upload-certs"
+  when: groups['masters']|length > 1 and inventory_hostname == groups['masters'][0]
+
+- name: generate join command for HA cluster
+  environment:
+    KUBECONFIG: /etc/kubernetes/admin.conf
+  shell: |
+    cert_key=$(kubeadm init phase upload-certs --upload-certs | tail -1)
+    kubeadm token create --print-join-command --certificate-key $cert_key
+  changed_when: false
+  when: groups['masters']|length > 1 and inventory_hostname == groups['masters'][0]
+  register: kubernetes_cp_join_command_result
+
+- name: Set the kubeadm join command for control plane nodes globally.
+  set_fact:
+    kubernetes_cp_join_command: >
+      {{ kubernetes_cp_join_command_result.stdout }}
+  when: kubernetes_cp_join_command_result.stdout is defined
+  delegate_to: "{{ item }}"
+  delegate_facts: true
+  with_items: "{{ groups['all'] }}"
+
+- name: kubeadm join control plane nodes
+  command: "{{ kubernetes_cp_join_command }}"
+  when: inventory_hostname != groups['masters'][0] and node_type == "master"
 
 - name: Create a directory ${HOME}/.kube if it does not exist
   file:
     path: ${HOME}/.kube/
     state: directory
     mode: '0755'
+  when: node_type == "master"
 
 - name: Copy the /etc/kubernetes/admin.conf to ${HOME}/.kube/config
   copy:
@@ -105,6 +133,6 @@
   delegate_facts: true
   with_items: "{{ groups['all'] }}"
 
-- name: kubeadm join
+- name: kubeadm join worker nodes
   command: "{{ kubernetes_join_command }}"
   when: node_type == "worker"

--- a/roles/install-k8s/templates/kubeadm.yaml.j2
+++ b/roles/install-k8s/templates/kubeadm.yaml.j2
@@ -26,6 +26,9 @@ networking:
   podSubnet: "{{ pod_subnet }}"
   dnsDomain: "cluster.local"
 kubernetesVersion: "{{ release_marker }}"
+{% if (loadbalancer is defined) and 'default.com' != loadbalancer %}
+controlPlaneEndpoint: "{{ loadbalancer }}:{{ apiserver_port }}"
+{% endif %}
 apiServer:
   timeoutForControlPlane: 4m0s
 {% if (extra_cert is defined) and extra_cert %}

--- a/roles/install-k8s/templates/kubeadm.yaml.j2
+++ b/roles/install-k8s/templates/kubeadm.yaml.j2
@@ -26,7 +26,7 @@ networking:
   podSubnet: "{{ pod_subnet }}"
   dnsDomain: "cluster.local"
 kubernetesVersion: "{{ release_marker }}"
-{% if (loadbalancer is defined) and 'default.com' != loadbalancer %}
+{% if (loadbalancer is defined) and '' != loadbalancer %}
 controlPlaneEndpoint: "{{ loadbalancer }}:{{ apiserver_port }}"
 {% endif %}
 apiServer:


### PR DESCRIPTION
Steps that involve setting up of multinode HA cluster.

```
2CP/2Worker setup using a load-balancer.
[root@p10-image-builder hack]# ./k8s-installer.sh -c "10.20.183.177 10.20.183.90" -w "10.20.183.81 10.20.183.18" -l 10.20.183.226 -r -y

10.20.183.177 is reachable
10.20.183.90 is reachable
10.20.183.81 is reachable
10.20.183.18 is reachable
Fetching latest k8s stable release version.
Stable release version to be used for cluster deployment: v1.32.2
Approved to run playbooks after initialization
No playbook has been passed, defaulting to install-k8s.yml
Ansible Playbook   : install-k8s.yml
Control Node IP    : 10.20.183.177 10.20.183.90
Worker Node IP(s)  : 10.20.183.81 10.20.183.18
...
...
PLAY RECAP ****************************************************************************************************************************************************************
10.20.183.177              : ok=35   changed=13   unreachable=0    failed=0    skipped=35   rescued=0    ignored=0
10.20.183.18               : ok=24   changed=8    unreachable=0    failed=0    skipped=35   rescued=0    ignored=0
10.20.183.81               : ok=24   changed=8    unreachable=0    failed=0    skipped=35   rescued=0    ignored=0
10.20.183.90               : ok=30   changed=10   unreachable=0    failed=0    skipped=40   rescued=0    ignored=0


[root@kishen-k8s-node-1 kubernetes]# kubectl get nodes
NAME                STATUS   ROLES           AGE   VERSION
kishen-k8s-node-1   Ready    control-plane   45s   v1.32.2
kishen-k8s-node-2   Ready    control-plane   28s   v1.32.2
kishen-k8s-node-3   Ready    <none>          22s   v1.32.2
kishen-k8s-node-4   Ready    <none>          22s   v1.32.2

```

```
1CP/1W setup
[root@p10-image-builder hack]# ./k8s-installer.sh -c 10.20.183.177 -w 10.20.183.90 -r -y
10.20.183.177 is reachable
10.20.183.90 is reachable
Fetching latest k8s stable release version.
Stable release version to be used for cluster deployment: v1.32.2
Approved to run playbooks after initialization
No playbook has been passed, defaulting to install-k8s.yml
Ansible Playbook   : install-k8s.yml
Control Node IP    : 10.20.183.177
Worker Node IP(s)  : 10.20.183.90
...
...
PLAY RECAP ****************************************************************************************************************************************************************
10.20.183.177              : ok=33   changed=14   unreachable=0    failed=0    skipped=37   rescued=0    ignored=0
10.20.183.90               : ok=24   changed=9    unreachable=0    failed=0    skipped=35   rescued=0    ignored=0


[root@kishen-k8s-node-1 kubernetes]# kubectl get nodes
NAME                STATUS   ROLES           AGE     VERSION
kishen-k8s-node-1   Ready    control-plane   3m7s    v1.32.2
kishen-k8s-node-2   Ready    <none>          2m54s   v1.32.2
```

Complete logs:
[2cp-2worker-logs.txt](https://github.com/user-attachments/files/19081197/2cp-2worker-logs.txt)
[1cp-1worker-logs.txt](https://github.com/user-attachments/files/19081205/1cp-1worker-logs.txt)

