### PR TITLE
Use corresponding package managers(dnf/yum) in applicable environments

### DIFF
--- a/roles/install-k8s/tasks/main.yml
+++ b/roles/install-k8s/tasks/main.yml
@@ -18,16 +18,14 @@
     hostnamectl set-hostname $(hostname | cut -d "." -f1)
 
 - name: Install prereq packages
-  yum:
-    name: "{{ packages }}"
-    state: present
-  vars:
-    packages:
+  package:
+    name:
       - conntrack-tools
       - socat
       - iproute-tc
       - iptables
-  when: ansible_pkg_mgr == 'yum'
+    state: present
+  when: ansible_pkg_mgr in ['yum', 'dnf']
 
 - name: Install prereq Ubuntu packages
   apt:

--- a/roles/k8s-node/tasks/main.yml
+++ b/roles/k8s-node/tasks/main.yml
@@ -10,15 +10,13 @@
     state: restarted
 
 - name: Install prereq packages
-  yum:
-    name: "{{ packages }}"
-    state: present
-  vars:
-    packages:
+  package:
+    name:
       - git
       - make
       - gcc
-  when: ansible_pkg_mgr == 'yum'
+    state: present
+  when: ansible_pkg_mgr in ['yum', 'dnf']
 
 - name: Update apt-get repo/cache and install prereq packages
   apt:

--- a/roles/k8s-ut/tasks/main.yml
+++ b/roles/k8s-ut/tasks/main.yml
@@ -1,13 +1,11 @@
 - name: Install prereq packages
-  yum:
-    name: "{{ packages }}"
-    state: present
-  vars:
-    packages:
+  package:
+    name:
       - git
       - make
       - gcc
-  when: ansible_pkg_mgr == 'yum'
+    state: present
+  when: ansible_pkg_mgr in ['yum','dnf']
 
 - name: Update apt-get repo/cache and install prereq packages
   apt:

--- a/roles/runtime/tasks/containerd.yaml
+++ b/roles/runtime/tasks/containerd.yaml
@@ -1,12 +1,12 @@
 ---
 - name: Install containerd dependencies
-  yum:
+  package:
     name:
       - device-mapper-persistent-data
       - lvm2
     state: present
     disable_gpg_check: true
-  when: ansible_pkg_mgr == 'yum'
+  when: ansible_pkg_mgr in ['yum', 'dnf']
 
 - name: Install containerd dependencies
   apt:

--- a/roles/runtime/tasks/crio.yaml
+++ b/roles/runtime/tasks/crio.yaml
@@ -1,11 +1,11 @@
 ---
 - name: Install CRI-O and dependencies.
-  yum:
+  package:
     name:
       - conmon
     state: present
     disable_gpg_check: true
-  when: ansible_pkg_mgr == 'yum' 
+  when: ansible_pkg_mgr in ['yum', 'dnf']
 
 - name: Install CRI-O and dependencies.
   apt:

--- a/roles/runtime/tasks/main.yaml
+++ b/roles/runtime/tasks/main.yaml
@@ -53,9 +53,9 @@
         remote_src: yes
 
     - name: Install iptables
-      yum:
+      package:
         name: iptables
-      when: ansible_pkg_mgr == 'yum'
+      when: ansible_pkg_mgr in ['yum', 'dnf']
 
     - name: Install iptables
       apt:


### PR DESCRIPTION
Since RHEL/CentOS 9 onwards, package manager dnf would be used, although yum would exist and will continue functioning. This PR is to address situations where `ansible_pkg_mgr` returned `dnf` at few instances, leading to skipping installing certain packages.

Ref: 
[Software management tools in Red Hat Enterprise Linux 9](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/managing_software_with_the_dnf_tool/index#con_software-management-tools-in-red-hat-enterprise-linux-9_managing-software-with-the-dnf-tool) 
[Yum has been deprecated as the default package manager in the Red Hat family of distributions](https://developers.redhat.com/articles/2022/10/07/move-apt-dnf-package-management#understanding_apt__dnf__and_yum)

Tests: Done, ran all available playbooks to confirm if it does work as intended.

Addl ref: [ansible.builtin.package](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/package_module.html)
