### PR TITLE
Update code to fetch latest stable K8s version for Knative

### DIFF
--- a/install-k8s-kn-tkn.yml
+++ b/install-k8s-kn-tkn.yml
@@ -2,6 +2,8 @@
   hosts:
     - masters
     - workers
+  vars:
+    directory: release
   roles:
     - runtime
     - download-k8s


### PR DESCRIPTION
## Issue Faced  
The **eventing-kafka broker** failed to start due to an incompatibility between the **latest Kubernetes version** and the **Fabric8 Kubernetes Client (v7.1.0)**. By default, the [job](https://github.com/ppc64le-cloud/test-infra/blob/9deb7ae090c436c7e75cf0ecd3405db1961f2cb9/config/jobs/periodic/knative-extensions/eventing-kafka-broker/eventing-kafka-broker-main.yaml#L35C40-L35C100) was pulling the latest Kubernetes build:  

```sh  
K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)  
```
which resulted in **v1.33.0-beta.0.696**.  

The new Kubernetes version introduced additional fields in the `/version` API response:  

```json  
{  
  "major": "1",  
  "minor": "33",  
  "emulationMajor": "1",  
  "emulationMinor": "33",  
  "minCompatibilityMajor": "1",  
  "minCompatibilityMinor": "32"  
}  
```
However, **Fabric8 Kubernetes Client (v7.1.0)** does not recognize these fields, causing **Jackson’s JSON parser to fail** with the error:  

```
Unrecognized field "emulationMajor" (class io.fabric8.kubernetes.client.VersionInfo)  
```

## Debugging  
The logs revealed that the failure occurred because Fabric8’s Kubernetes client could not deserialize the newly introduced fields in the `/version` API response. This prevented Strimzi Kafka from fetching the Kubernetes version properly, leading to the broker failure.  

## Fix  
To resolve the issue, we fetched the **stable release (v1.32.3)** of Kubernetes instead of the latest development build. This ensured compatibility, and the **Strimzi Kafka Operator** started successfully:  

```sh  
Waiting until all pods in namespace kafka are up...  
All pods are up:  
my-cluster-zookeeper-0                      1/1   Running   0     68s  
my-cluster-zookeeper-1                      1/1   Running   0     68s  
my-cluster-zookeeper-2                      1/1   Running   0     68s  
strimzi-cluster-operator-76b947897f-m799t   1/1   Running   0     92s  
```
